### PR TITLE
fix(gui): better-sqlite compiled with different node version

### DIFF
--- a/.changeset/early-bulldogs-punch.md
+++ b/.changeset/early-bulldogs-punch.md
@@ -1,0 +1,5 @@
+---
+"deemix-gui": minor
+---
+
+Fix error with better-sqlite package not being found

--- a/.github/workflows/build-release-electron.yml
+++ b/.github/workflows/build-release-electron.yml
@@ -52,6 +52,7 @@ jobs:
         run: echo "PYTHON=$(which python)" >> $GITHUB_ENV
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter=deemix-gui exec pnpm electron-rebuild
 
       - run: pnpm make
 


### PR DESCRIPTION
## What?

Rebuild electron binaries before building GUI package

## Why?

#123 - actual error seems to be that the better-sqlite3 package is being cached from a previous version of node

## How?

Running `electron-rebuild` after installing dependencies during electron build workflow.
