### PR TITLE
fix(gui): manually copy better_sqlite3.node to gui build

### DIFF
--- a/.changeset/thin-mugs-teach.md
+++ b/.changeset/thin-mugs-teach.md
@@ -1,0 +1,5 @@
+---
+"deemix-gui": patch
+---
+
+Fix missing sqlite library causing crash

--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
 		]
 	},
 	"dependencies": {
-		"better-sqlite3": "^11.3.0"
+		"better-sqlite3": "^11.4.0"
 	},
 	"devDependencies": {
 		"@yao-pkg/pkg": "^5.15.0",

--- a/gui/.gitignore
+++ b/gui/.gitignore
@@ -1,0 +1,1 @@
+build/better_sqlite3.node

--- a/gui/package.json
+++ b/gui/package.json
@@ -28,11 +28,12 @@
 		"@types/yargs": "^17.0.32",
 		"electron": "32.0.2",
 		"esbuild": "^0.23.1",
+		"esbuild-plugin-copy": "^2.1.1",
 		"node-gyp": "^10.2.0",
 		"tsup": "^8.2.4"
 	},
 	"dependencies": {
-		"better-sqlite3": "^11.3.0",
+		"better-sqlite3": "^11.4.0",
 		"deemix-webui": "workspace:*",
 		"electron-context-menu": "^4.0.4",
 		"electron-squirrel-startup": "^1.0.1",

--- a/gui/scripts/build.js
+++ b/gui/scripts/build.js
@@ -1,10 +1,11 @@
 import * as esbuild from "esbuild";
+import copy from "esbuild-plugin-copy";
 import fsp from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import url from "node:url";
 import { getArg, hasArg, log } from "./utils.js";
 
-import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json");
 
@@ -53,7 +54,7 @@ async function main(argv) {
 				outfile: "./dist/main.js",
 				target: "esnext",
 				format: "esm",
-				external: ["electron", "lightningcss", "better-sqlite3"],
+				external: ["electron", "lightningcss"],
 				define: {
 					"process.env.NODE_ENV": JSON.stringify(BUILD_MODE),
 					"process.env.GUI_VERSION": JSON.stringify(packageJson.version),
@@ -62,8 +63,19 @@ async function main(argv) {
 					".node": "copy",
 					".png": "file",
 				},
-				plugins: [log],
+				plugins: [
+					log,
+					copy({
+						assets: [
+							{
+								from: "./node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+								to: "../build/better_sqlite3.node",
+							},
+						],
+					}),
+				],
 			};
+
 			if (IS_WATCH) {
 				await esbuild.context(options).then((ctx) => ctx.watch());
 			} else {
@@ -85,6 +97,7 @@ async function main(argv) {
 				sourcemap: true,
 				plugins: [log],
 			};
+
 			if (IS_WATCH) {
 				await esbuild.context(options).then((ctx) => ctx.watch());
 			} else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
   cli:
     dependencies:
       better-sqlite3:
-        specifier: ^11.3.0
-        version: 11.3.0
+        specifier: ^11.4.0
+        version: 11.4.0
     devDependencies:
       '@yao-pkg/pkg':
         specifier: ^5.15.0
@@ -147,7 +147,7 @@ importers:
     dependencies:
       '@resolid/cache-manager-sqlite':
         specifier: ^5.1.6
-        version: 5.1.6(better-sqlite3@11.3.0)(cache-manager@5.7.6)
+        version: 5.1.6(better-sqlite3@11.4.0)(cache-manager@5.7.6)
       cache-manager:
         specifier: ^5.7.6
         version: 5.7.6
@@ -174,8 +174,8 @@ importers:
   gui:
     dependencies:
       better-sqlite3:
-        specifier: ^11.3.0
-        version: 11.3.0
+        specifier: ^11.4.0
+        version: 11.4.0
       deemix-webui:
         specifier: workspace:*
         version: link:../webui
@@ -225,6 +225,9 @@ importers:
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
+      esbuild-plugin-copy:
+        specifier: ^2.1.1
+        version: 2.1.1(esbuild@0.23.1)
       node-gyp:
         specifier: ^10.2.0
         version: 10.2.0
@@ -1702,8 +1705,8 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.3.0:
-    resolution: {integrity: sha512-iHt9j8NPYF3oKCNOO5ZI4JwThjt3Z6J6XrcwG85VNMVzv1ByqrHWv5VILEbCMFWDsoHhXvQ7oC8vgRXFAKgl9w==}
+  better-sqlite3@11.4.0:
+    resolution: {integrity: sha512-B7C9y2aSvtTwDJIz34iUxMjQWmbAYFmpq0Rwf9weYTtx6jUYsUKVt5ePPYlGyLVBoySppPa41PBrzl1ipMhG7A==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2339,6 +2342,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild-plugin-copy@2.1.1:
+    resolution: {integrity: sha512-Bk66jpevTcV8KMFzZI1P7MZKZ+uDcrZm2G2egZ2jNIvVnivDpodZI+/KnpL3Jnap0PBdIHU7HwFGB8r+vV5CVw==}
+    peerDependencies:
+      esbuild: '>= 0.14.0'
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -6206,9 +6214,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@resolid/cache-manager-sqlite@5.1.6(better-sqlite3@11.3.0)(cache-manager@5.7.6)':
+  '@resolid/cache-manager-sqlite@5.1.6(better-sqlite3@11.4.0)(cache-manager@5.7.6)':
     dependencies:
-      better-sqlite3: 11.3.0
+      better-sqlite3: 11.4.0
       cache-manager: 5.7.6
 
   '@rollup/rollup-android-arm-eabi@4.21.2':
@@ -6897,7 +6905,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.3.0:
+  better-sqlite3@11.4.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2
@@ -7599,6 +7607,14 @@ snapshots:
 
   es6-error@4.1.1:
     optional: true
+
+  esbuild-plugin-copy@2.1.1(esbuild@0.23.1):
+    dependencies:
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      esbuild: 0.23.1
+      fs-extra: 10.1.0
+      globby: 11.1.0
 
   esbuild@0.21.5:
     optionalDependencies:


### PR DESCRIPTION
## What?
Manually copy `better_sqlite3.node` file to build dir when building gui

## Why?
Electron forge doesn't want to copy it over, no matter what I try. This feels a bit hacky, but it at least does the job!

