### PR TITLE
build(gui): publish as deb file

### DIFF
--- a/.changeset/purple-parts-lie.md
+++ b/.changeset/purple-parts-lie.md
@@ -1,0 +1,5 @@
+---
+"deemix-gui": patch
+---
+
+Added deb maker to the releases

--- a/.github/workflows/build-release-electron.yml
+++ b/.github/workflows/build-release-electron.yml
@@ -64,3 +64,4 @@ jobs:
             gui/out/**/Deemix.exe
             gui/out/**/Deemix*Setup.exe
             gui/out/make/zip/**/*.zip
+            gui/out/make/deb/**/*.deb

--- a/gui/forge.config.js
+++ b/gui/forge.config.js
@@ -14,6 +14,7 @@ export default {
 			/^\/tsconfig.json/,
 		],
 		icon: "./build/icon.ico",
+		executableName: "deemix-gui",
 	},
 	rebuildConfig: {},
 	makers: [
@@ -24,6 +25,18 @@ export default {
 		{
 			name: "@electron-forge/maker-zip",
 			config: {},
+		},
+		{
+			name: "@electron-forge/maker-deb",
+			config: {
+				options: {
+					name: "deemix",
+					productName: "Deemix",
+					section: "sound",
+					icon: "./build/icon.ico",
+					categories: ["Audio"],
+				},
+			},
 		},
 	],
 	plugins: [


### PR DESCRIPTION
## What?
Added .deb as a released package
## Why?
I would like to install Deemix into my system. I used the AppImage release from the original deemix but electron forge does not have an official maker, so this was the second choice.
## How?
By adding the deb-maker
