### PR TITLE
fix(deemix): fix folder name generation for playlists

### DIFF
--- a/.changeset/whole-seals-obey.md
+++ b/.changeset/whole-seals-obey.md
@@ -1,0 +1,5 @@
+---
+"deemix": minor
+---
+
+Fix name generation for %playlist% replacement

--- a/deemix/src/utils/pathtemplates.ts
+++ b/deemix/src/utils/pathtemplates.ts
@@ -434,6 +434,11 @@ export function generateDownloadObjectName(
 	foldername = foldername.replaceAll("%size%", queueItem.size);
 	foldername = foldername.replaceAll("%type%", fixName(queueItem.type, c));
 	foldername = foldername.replaceAll("%id%", fixName(queueItem.id, c));
+	if (queueItem.type === "playlist" && queueItem.collection && queueItem.collection.playlistAPI) {
+		foldername = foldername.replaceAll("%playlist%", fixName(queueItem.collection.playlistAPI.title, c));
+	} else {
+		foldername = foldername.replaceAll("%playlist%", fixName(queueItem.title, c));
+	}
 	foldername = foldername.replaceAll(
 		"%bitrate%",
 		bitrateLabels[parseInt(queueItem.bitrate)]

--- a/deemix/src/utils/pathtemplates.ts
+++ b/deemix/src/utils/pathtemplates.ts
@@ -322,6 +322,11 @@ export function generateAlbumName(
 		fixName(album.artists.join(", "), c)
 	);
 	foldername = foldername.replaceAll("%artist_id%", album.mainArtist.id);
+	if (playlist) {
+		foldername = foldername.replaceAll("%playlist%", fixName(playlist.title, c));
+	} else {
+		foldername = foldername.replaceAll("%playlist%", fixName(album.title, c));
+	}
 	if (album.rootArtist) {
 		foldername = foldername.replaceAll(
 			"%root_artist%",


### PR DESCRIPTION
## What?

Implement %playlist% replacement properly

## Why?

So the replacements including that string can properly be named

## How?

Add the replacement rule

## Screenshots (if applicable)

N/A 

Fixes #175