### PR TITLE
feat(webui): add hint for spotify username

### DIFF
--- a/.changeset/metal-carrots-call.md
+++ b/.changeset/metal-carrots-call.md
@@ -1,0 +1,5 @@
+---
+"deemix-webui": patch
+---
+
+Add hint for spotify username to explain that it's the public username, not the one used to sign in

--- a/webui/src/client/lang/en.mjs
+++ b/webui/src/client/lang/en.mjs
@@ -466,6 +466,8 @@ const en = {
 			clientID: "Spotify ClientID",
 			clientSecret: "Spotify Client Secret",
 			username: "Spotify Username",
+			usernameHint:
+				"Your public username used for grabbing your public playlists. Not the username you use to sign in.",
 			question: "How do I enable Spotify Features?",
 			howTo: {
 				prologue: {

--- a/webui/src/client/views/SettingsPage.vue
+++ b/webui/src/client/views/SettingsPage.vue
@@ -1353,6 +1353,9 @@ function canDownload(bitrate: number) {
 
 			<div class="input-group">
 				<p class="input-group-text">{{ t("settings.spotify.username") }}</p>
+				<p class="input-group-text text-sm text-gray-400">
+					{{ t("settings.spotify.usernameHint") }}
+				</p>
 				<input v-model="spotifyUser" type="text" />
 			</div>
 
@@ -1461,6 +1464,8 @@ function canDownload(bitrate: number) {
 }
 
 /* Input group */
+.input-group {
+}
 .input-group .input-group-text {
 	margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Add hint to spotify settings

## Screenshots (if applicable)
![{264DBBB4-0F0E-43AF-BFB8-742A944F9873}](https://github.com/user-attachments/assets/c9aaca1d-ecd3-4924-ab97-8220160ba732)
