### PR TITLE
fix(deemix): itunes compilation id3 tag not saving

### DIFF
--- a/.changeset/gold-toys-buy.md
+++ b/.changeset/gold-toys-buy.md
@@ -1,0 +1,5 @@
+---
+"deemix": patch
+---
+
+Fix itunes compilation flag not saving correctly

--- a/deemix/package.json
+++ b/deemix/package.json
@@ -23,7 +23,7 @@
 	"dependencies": {
 		"@spotify/web-api-ts-sdk": "^1.2.0",
 		"async": "^3.2.0",
-		"browser-id3-writer": "^6.1.0",
+		"browser-id3-writer": "^6.2.0",
 		"deezer-sdk": "workspace:*",
 		"got": "^14.4.2",
 		"html-entities": "^2.3.3",

--- a/deemix/src/utils/downloadUtils.ts
+++ b/deemix/src/utils/downloadUtils.ts
@@ -1,7 +1,8 @@
+import type { Tags } from "@/types/Settings.js";
+import type Track from "@/types/Track.js";
 import fs from "fs";
 import { OverwriteOption } from "../settings.js";
 import { tagFLAC, tagID3 } from "../tagger.js";
-import type Track from "@/types/Track.js";
 
 export const checkShouldDownload = (
 	filename: string,
@@ -55,7 +56,12 @@ export const checkShouldDownload = (
 	return !trackAlreadyDownloaded;
 };
 
-export const tagTrack = (extension, writepath, track, tags) => {
+export const tagTrack = (
+	extension: string,
+	writepath: string,
+	track,
+	tags: Tags
+) => {
 	if (extension === ".mp3") {
 		tagID3(writepath, track, tags);
 	} else if (extension === ".flac") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.6
       browser-id3-writer:
-        specifier: ^6.1.0
-        version: 6.1.0
+        specifier: ^6.2.0
+        version: 6.2.0
       deezer-sdk:
         specifier: workspace:*
         version: link:../deezer-sdk
@@ -2305,8 +2305,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browser-id3-writer@6.1.0:
-    resolution: {integrity: sha512-99mQN3GAZlqWnbA0cispSAab9uJJzzv86ffoA/w6ohfqAi/5qOGbEhh0fRAQMrnhsOBsy89mqMc+JdnaWtJObw==}
+  browser-id3-writer@6.2.0:
+    resolution: {integrity: sha512-1tZPvkQ1LpGLS/bLXtic/rUkcOjfZpfvPcSxyMBnt7eA1VmNiKeJjKj3m/0UhNLOOp84fEn9uOuGS827CYQjlg==}
 
   browserslist@4.23.3:
     resolution: {integrity: sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==}
@@ -6411,7 +6411,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.6.3
+      semver: 7.7.1
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -7013,7 +7013,7 @@ snapshots:
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.1
 
   '@npmcli/fs@3.1.1':
     dependencies:
@@ -7823,7 +7823,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browser-id3-writer@6.1.0: {}
+  browser-id3-writer@6.2.0: {}
 
   browserslist@4.23.3:
     dependencies:
@@ -9276,7 +9276,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10756,7 +10756,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.4.0
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

- Update `browser-id3-writer` package to latest version for TCMP tag support
- I've disabled saving rating under `POPM` since the library doesn't support it (will investigate further)
