### PR TITLE
feat: Add Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  deemix:
+    container_name: Deemix
+    build: .
+    restart: unless-stopped
+    ports:
+      - 6595:6595
+    volumes:
+      - /var/lib/deemix:/config
+      - /path/to/music:/downloads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
     ports:
       - 6595:6595
     volumes:
-      - ${DEEMIX_CONFIG_PATH}:/config   # Set the `DEEMIX_CONFIG_PATH` environment variable in the shell where `docker-compose up` is being ran
-      - ${DEEMIX_MUSIC_PATH}:/downloads # Set the `DEEMIX_MUSIC_PATH` environment variable in the shell where `docker-compose up` is being ran
+      - "${DEEMIX_CONFIG_PATH}:/config"   # Set the `DEEMIX_CONFIG_PATH` environment variable in the shell where `docker-compose up` is being ran
+      - "${DEEMIX_MUSIC_PATH}:/downloads" # Set the `DEEMIX_MUSIC_PATH` environment variable in the shell where `docker-compose up` is being ran

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
     ports:
       - 6595:6595
     volumes:
-      - /var/lib/deemix:/config
-      - /path/to/music:/downloads
+      - ${DEEMIX_CONFIG_PATH}:/config   # Set the `DEEMIX_CONFIG_PATH` environment variable in the shell where `docker-compose up` is being ran
+      - ${DEEMIX_MUSIC_PATH}:/downloads # Set the `DEEMIX_MUSIC_PATH` environment variable in the shell where `docker-compose up` is being ran


### PR DESCRIPTION
## What?

This adds a `docker-compose.yml` file to the root of the repository. The compose file builds the container using the existing `Dockerfile`. It uses environment variables for paths so they can be set externally

## Why?
* Using `docker-compose` allows end-users to leverage all its lifecycle benefits when running container instances.
* I like to manage container instances with an orchestration tool (like [portainer](https://docs.portainer.io/user/docker/stacks/add#option-3-git-repository)). Using a docker-compose stack makes this easier


## How?
#### Shell
```shell
$ export DEEMIX_CONFIG_PATH=/var/lib/deemix
$ export DEEMIX_MUSIC_PATH=/music
$ docker compose up -d
```

#### Portainer
1. Follow the instructions in the portainer [documentation](https://docs.portainer.io/user/docker/stacks/add#option-3-git-repository) for using a repository source in a new Stack. 
2. Paste in this repository's URL in the `Repository` field.
3. Add two new Environment variables `DEEMIX_CONFIG_PATH` and `DEEMIX_MUSIC_PATH`. Fill them in with the locations you want to use
4. Press `Deploy the Stack`

## Screenshots (if applicable)
