### PR TITLE
fix(webui): download button always showing 0 for favourites

### DIFF
--- a/.changeset/eighty-pugs-brake.md
+++ b/.changeset/eighty-pugs-brake.md
@@ -1,0 +1,5 @@
+---
+"deemix-webui": patch
+---
+
+Fix favourites download button always showing 0

--- a/webui/src/client/views/FavoritesView.vue
+++ b/webui/src/client/views/FavoritesView.vue
@@ -20,8 +20,9 @@ const state = reactive<{
 	tabs: typeof tabs;
 }>({
 	activeTab: "playlist",
-	tabs: ["playlist", "album", "artist", "track"],
+	tabs,
 });
+
 const {
 	favoriteArtists,
 	favoriteAlbums,
@@ -103,18 +104,6 @@ function getActiveRelease(tab?: (typeof state.tabs)[number]) {
 	return toDownload;
 }
 
-function getTabLength(tab?: (typeof tabs)[number]) {
-	if (!tab) tab = state.activeTab;
-
-	let total = state.tabs[`${tab}s`]?.length;
-
-	if (tab === "playlist") {
-		total += favoriteSpotifyPlaylists.value.length;
-	}
-
-	return total || 0;
-}
-
 function getLovedTracksPlaylist() {
 	const lovedTracks = favoritePlaylists.value.filter((playlist) => {
 		return playlist.is_loved_track;
@@ -171,7 +160,10 @@ const activeTabEmpty = computed(() => {
 		>
 			{{
 				t("globals.download", {
-					thing: t(`globals.listTabs.${state.activeTab}N`, getTabLength()),
+					thing: t(
+						`globals.listTabs.${state.activeTab}N`,
+						getActiveRelease().length
+					),
 				})
 			}}
 		</button>


### PR DESCRIPTION
## Summary

- Fix the download button on the favourites pages (tracks, albums, artists) always showing 0
- Resolves #148 

## Screenshots (if applicable)

Before:
<img width="1038" height="539" alt="{14518354-EAD2-4FC7-8739-CED9598C2129}" src="https://github.com/user-attachments/assets/e33587df-4ad7-41b9-a169-b4fe24554e1c" />

After:
<img width="1033" height="552" alt="{6CF9C30D-38C7-40D8-A5D6-8154B0B59345}" src="https://github.com/user-attachments/assets/354e4dd9-5762-4c80-853a-2a615f5e2610" />


## Checklist

- [x] I have tested the changes locally and they work as expected
- [x] This PR contains a changeset (`pnpm changeset`)
