### PR TITLE
Support listenbrainz playlist URLs

### DIFF
--- a/.changeset/funny-pillows-rush.md
+++ b/.changeset/funny-pillows-rush.md
@@ -1,0 +1,6 @@
+---
+"deemix": minor
+"deemix-webui": minor
+---
+
+Add support for listenbrainz playlists

--- a/packages/deemix/src/downloader.ts
+++ b/packages/deemix/src/downloader.ts
@@ -703,7 +703,10 @@ export class Downloader {
 
 		for (let i = 0; i < tracks.length; i++) {
 			const track = tracks[i];
-			if (!track) return;
+			if (!track) {
+				playlist[i] = "";
+				continue;
+			}
 
 			if (track.error) {
 				if (!track.error.data)

--- a/packages/deemix/src/plugins/index.ts
+++ b/packages/deemix/src/plugins/index.ts
@@ -1,1 +1,2 @@
 export { default as SpotifyPlugin } from "./spotify.js";
+export { default as ListenBrainzPlugin } from "./listenbrainz.js";

--- a/packages/deemix/src/plugins/listenbrainz.ts
+++ b/packages/deemix/src/plugins/listenbrainz.ts
@@ -1,0 +1,269 @@
+import { Collection, Convertable } from "@/download-objects/Collection.js";
+import {
+	AlbumNotOnDeezer,
+	InvalidID,
+	PluginNotEnabledError,
+	TrackNotOnDeezer,
+} from "@/errors.js";
+import { type Settings } from "@/types/Settings.js";
+import { getConfigFolder } from "@/utils/localpaths.js";
+import { queue } from "async";
+import { Deezer, type DeezerTrack } from "deezer-sdk";
+import fs from "fs";
+import got from "got";
+import { sep } from "path";
+import BasePlugin from "./base.js";
+
+interface ListenBrainzTrack {
+	creator: string;
+	title: string;
+	album: string;
+	duration: number;
+	extension: {
+		additional_metadata: {
+			artist_mbids: string[];
+			recording_mbid: string;
+			release_mbid: string;
+			track_mbid: string;
+		};
+	};
+	identifier: string;
+}
+
+export default class ListenBrainzPlugin extends BasePlugin {
+	enabled: boolean;
+	configFolder: string;
+
+	constructor(configFolder = undefined) {
+		super();
+		this.enabled = false;
+		this.configFolder = configFolder || getConfigFolder();
+		this.configFolder += `listenbrainz${sep}`;
+		return this;
+	}
+
+	override setup() {
+		fs.mkdirSync(this.configFolder, { recursive: true });
+		this.enabled = true;
+		return this;
+	}
+
+	override async parseLink(link: string) {
+		if (link.includes("listenbrainz.org/playlist/")) {
+			const match = /playlist\/([a-f0-9-]+)/.exec(link);
+			if (match) {
+				return [link, "playlist", match[1]];
+			}
+		}
+		return [link, undefined, undefined];
+	}
+
+	override async generateDownloadObject(dz, link, bitrate) {
+		let link_type, link_id;
+		[link, link_type, link_id] = await this.parseLink(link);
+
+		if (link_type == null || link_id == null) return null;
+
+		switch (link_type) {
+			case "playlist":
+				return this.generatePlaylistItem(dz, link_id, bitrate, link);
+		}
+	}
+
+	async generatePlaylistItem(dz: Deezer, link_id: string, bitrate: number, link: string) {
+		if (!this.enabled) throw new PluginNotEnabledError("ListenBrainz");
+
+		const response = await got
+			.post(link, {
+				headers: {
+					Accept: "application/json",
+				},
+			})
+			.json<any>();
+
+		// The playlist data is nested under a 'playlist' key, which is also nested
+		const listenBrainzPlaylist = response.playlist.playlist;
+
+		console.log(
+			"ListenBrainz Playlist Keys:",
+			Object.keys(listenBrainzPlaylist)
+		);
+
+		const playlistAPI: any = this._convertPlaylistStructure(listenBrainzPlaylist);
+		playlistAPI.various_artist = await dz.api.get_artist(5080); // Useful for save as compilation
+
+		const tracklist: ListenBrainzTrack[] = listenBrainzPlaylist.track || [];
+
+		return new Convertable({
+			type: "listenbrainz_playlist",
+			id: link_id,
+			bitrate,
+			title: listenBrainzPlaylist.title,
+			artist: listenBrainzPlaylist.creator,
+			cover: playlistAPI.picture_thumbnail,
+			explicit: false, // ListenBrainz does not provide this
+			size: tracklist.length,
+			collection: {
+				tracks: [],
+				playlistAPI,
+			},
+			plugin: "listenbrainz",
+			conversion_data: tracklist,
+		});
+	}
+
+	async convert(
+		dz: Deezer,
+		downloadObject: Convertable,
+		settings: Settings,
+		listener: any = null
+	): Promise<Collection> {
+		const collection = [];
+		let conversion = 0;
+		let conversionNext = 0;
+
+		if (listener)
+			listener.send("startConversion", {
+				uuid: downloadObject.uuid,
+				title: downloadObject.title,
+			});
+
+		const q = queue(
+			async (data: { track: ListenBrainzTrack; pos: number }, callback) => {
+				const { track, pos } = data;
+				if (downloadObject.isCanceled) return;
+
+				if (listener) {
+					const progress = ((pos + 1) / downloadObject.size) * 100;
+					listener.send("updateQueue", {
+						uuid: downloadObject.uuid,
+						title: downloadObject.title,
+						conversion: Math.round(progress),
+					});
+					console.log(
+						`Converting track ${pos + 1}/${downloadObject.size}: ${
+							track.creator
+						} - ${track.title}`
+					);
+				}
+
+				let trackAPI: DeezerTrack;
+
+				const artist = track.creator || "";
+				const title = track.title || "";
+				const album = track.album || "";
+
+				const trackID = await dz.api.get_track_id_from_metadata(
+					artist,
+					title,
+					album
+				);
+
+				if (trackID !== "0") trackAPI = await dz.api.getTrack(trackID);
+
+				if (!trackAPI) {
+					trackAPI = {
+						id: "0",
+						title: title,
+						duration: 0,
+						md5_origin: 0,
+						media_version: 0,
+						filesizes: {},
+						album: {
+							title: album,
+							md5_image: "",
+						},
+						artist: {
+							id: 0,
+							name: artist,
+							md5_image: "",
+						},
+					};
+				}
+
+				trackAPI.position = pos + 1;
+				collection[pos] = trackAPI;
+
+				callback();
+			},
+			settings.queueConcurrency
+		);
+
+		(downloadObject.conversionData as any[]).forEach(
+			(track: ListenBrainzTrack, pos) => {
+				q.push({ track, pos }, () => {});
+			}
+		);
+
+		await q.drain();
+
+		downloadObject.collection.tracks = collection;
+		downloadObject.size = collection.length;
+
+		const returnCollection = new Collection(downloadObject.toDict());
+		if (listener)
+			listener.send("finishConversion", returnCollection.getSlimmedDict());
+
+		return returnCollection;
+	}
+
+	_convertPlaylistStructure(listenBrainzPlaylist) {
+		const cover = listenBrainzPlaylist.meta?.artwork;
+
+		let creation_date = "0000-00-00";
+		if (listenBrainzPlaylist.date) {
+			try {
+				const date = new Date(listenBrainzPlaylist.date);
+				if (date && !isNaN(date.getTime()))
+					creation_date = date.toISOString().split("T")[0];
+			} catch (e) {
+				console.error("Error parsing date:", e);
+				console.error("Original date value:", listenBrainzPlaylist.date);
+			}
+		}
+
+		const deezerPlaylist = {
+			checksum: listenBrainzPlaylist.identifier,
+			collaborative: false,
+			creation_date,
+			creator: {
+				id: listenBrainzPlaylist.creator,
+				name: listenBrainzPlaylist.creator,
+				tracklist: listenBrainzPlaylist.identifier,
+				type: "user",
+			},
+			description: listenBrainzPlaylist.annotation,
+			duration: 0,
+			fans: 0,
+			id: listenBrainzPlaylist.identifier,
+			is_loved_track: false,
+			link: listenBrainzPlaylist.identifier,
+			nb_tracks: listenBrainzPlaylist.track
+				? listenBrainzPlaylist.track.length
+				: 0,
+			picture: cover,
+			picture_small:
+				cover ||
+				"https://e-cdns-images.dzcdn.net/images/cover/d41d8cd98f00b204e9800998ecf8427e/56x56-000000-80-0-0.jpg",
+			picture_medium:
+				cover ||
+				"https://e-cdns-images.dzcdn.net/images/cover/d41d8cd98f00b204e9800998ecf8427e/250x250-000000-80-0-0.jpg",
+			picture_big:
+				cover ||
+				"https://e-cdns-images.dzcdn.net/images/cover/d41d8cd98f00b204e9800998ecf8427e/500x500-000000-80-0-0.jpg",
+			picture_xl:
+				cover ||
+				"https://e-cdns-images.dzcdn.net/images/cover/d41d8cd98f00b204e9800998ecf8427e/1000x1000-000000-80-0-0.jpg",
+			picture_thumbnail:
+				cover ||
+				"https://e-cdns-images.dzcdn.net/images/cover/d41d8cd98f00b204e9800998ecf8427e/75x75-000000-80-0-0.jpg",
+			public: true,
+			share: listenBrainzPlaylist.identifier,
+			title: listenBrainzPlaylist.title,
+			tracklist: listenBrainzPlaylist.identifier,
+			type: "playlist",
+		};
+
+		return deezerPlaylist;
+	}
+}

--- a/packages/deemix/src/plugins/listenbrainz.ts
+++ b/packages/deemix/src/plugins/listenbrainz.ts
@@ -1,10 +1,5 @@
 import { Collection, Convertable } from "@/download-objects/Collection.js";
-import {
-	AlbumNotOnDeezer,
-	InvalidID,
-	PluginNotEnabledError,
-	TrackNotOnDeezer,
-} from "@/errors.js";
+import { PluginNotEnabledError } from "@/errors.js";
 import { type Settings } from "@/types/Settings.js";
 import { getConfigFolder } from "@/utils/localpaths.js";
 import { queue } from "async";
@@ -84,11 +79,6 @@ export default class ListenBrainzPlugin extends BasePlugin {
 		// The playlist data is nested under a 'playlist' key, which is also nested
 		const listenBrainzPlaylist = response.playlist.playlist;
 
-		console.log(
-			"ListenBrainz Playlist Keys:",
-			Object.keys(listenBrainzPlaylist)
-		);
-
 		const playlistAPI: any = this._convertPlaylistStructure(listenBrainzPlaylist);
 		playlistAPI.various_artist = await dz.api.get_artist(5080); // Useful for save as compilation
 
@@ -119,8 +109,6 @@ export default class ListenBrainzPlugin extends BasePlugin {
 		listener: any = null
 	): Promise<Collection> {
 		const collection = [];
-		let conversion = 0;
-		let conversionNext = 0;
 
 		if (listener)
 			listener.send("startConversion", {
@@ -140,11 +128,6 @@ export default class ListenBrainzPlugin extends BasePlugin {
 						title: downloadObject.title,
 						conversion: Math.round(progress),
 					});
-					console.log(
-						`Converting track ${pos + 1}/${downloadObject.size}: ${
-							track.creator
-						} - ${track.title}`
-					);
 				}
 
 				let trackAPI: DeezerTrack;

--- a/packages/deezer-sdk/src/api.ts
+++ b/packages/deezer-sdk/src/api.ts
@@ -13,6 +13,11 @@ import {
 } from "./errors.js";
 import { SearchOrder, type APIAlbum, type APIOptions } from "./index.js";
 import { trackSchema, type DeezerTrack } from "./schema/track-schema.js";
+import {
+	compareStrings,
+	clean_search_query,
+	strip_presentation_info,
+} from "./utils.js";
 
 type APIArgs = Record<string | number, string | number>;
 
@@ -494,6 +499,8 @@ export class API {
 	}
 
 	async get_track_id_from_metadata(artist, track, album) {
+		const originalArtist = artist;
+		const originalTrack = track;
 		artist = artist.replace("–", "-").replace("’", "'");
 		track = track.replace("–", "-").replace("’", "'");
 		album = album.replace("–", "-").replace("’", "'");
@@ -518,6 +525,60 @@ export class API {
 				track: track.split(" - ")[0],
 			});
 			if (resp.data.length) return resp.data[0].id;
+		}
+
+		// Fuzzy match fallback
+		// Try a broader search with cleaned terms
+		const cleanArtistQuery = clean_search_query(artist);
+		const cleanTrackQuery = clean_search_query(track);
+		resp = await this.search_track(`${cleanArtistQuery} ${cleanTrackQuery}`);
+
+		if (resp.data && resp.data.length > 0) {
+			let bestMatchId = "0";
+			let bestScore = 0;
+
+			for (const item of resp.data) {
+				// Artist Comparison
+				let artistScore = compareStrings(originalArtist, item.artist.name);
+				const cleanArtist = clean_search_query(originalArtist);
+				if (cleanArtist !== originalArtist) {
+					const s = compareStrings(cleanArtist, item.artist.name);
+					if (s > artistScore) artistScore = s;
+				}
+
+				// Track Comparison
+				const trackCandidates = [
+					originalTrack,
+					clean_search_query(originalTrack),
+					strip_presentation_info(originalTrack),
+				];
+				if (originalTrack.includes("("))
+					trackCandidates.push(originalTrack.split("(")[0].trim());
+				if (originalTrack.includes(" - "))
+					trackCandidates.push(originalTrack.split(" - ")[0].trim());
+
+				const deezerCandidates = [item.title];
+				if (item.title_short) deezerCandidates.push(item.title_short);
+
+				let bestTitleScore = 0;
+				for (const t1 of trackCandidates) {
+					for (const t2 of deezerCandidates) {
+						const s = compareStrings(t1, t2);
+						if (s > bestTitleScore) bestTitleScore = s;
+					}
+				}
+
+				const totalScore = (artistScore + bestTitleScore) / 2;
+
+				if (totalScore > bestScore && totalScore > 0.6) {
+					if (artistScore > 0.4 && bestTitleScore > 0.4) {
+						bestScore = totalScore;
+						bestMatchId = item.id;
+					}
+				}
+			}
+
+			if (bestMatchId !== "0") return bestMatchId;
 		}
 
 		return "0";

--- a/packages/deezer-sdk/src/utils.ts
+++ b/packages/deezer-sdk/src/utils.ts
@@ -596,3 +596,57 @@ export function clean_search_query(term) {
 	term = term.replace(" & ", " ").replace("–", "-").replace("—", "-");
 	return term;
 }
+
+export function levenshtein(a: string, b: string): number {
+	if (a.length === 0) return b.length;
+	if (b.length === 0) return a.length;
+
+	const matrix: number[][] = Array(b.length + 1)
+		.fill(null)
+		.map(() => Array(a.length + 1).fill(0));
+
+	// increment along the first column of each row
+	for (let i = 0; i <= b.length; i++) {
+		matrix[i]![0] = i;
+	}
+
+	// increment each column in the first row
+	for (let j = 0; j <= a.length; j++) {
+		matrix[0]![j] = j;
+	}
+
+	// Fill in the rest of the matrix
+	for (let i = 1; i <= b.length; i++) {
+		for (let j = 1; j <= a.length; j++) {
+			if (b.charAt(i - 1) === a.charAt(j - 1)) {
+				matrix[i]![j] = matrix[i - 1]![j - 1]!;
+			} else {
+				matrix[i]![j] = Math.min(
+					matrix[i - 1]![j - 1]! + 1, // substitution
+					Math.min(
+						matrix[i]![j - 1]! + 1, // insertion
+						matrix[i - 1]![j]! + 1 // deletion
+					)
+				);
+			}
+		}
+	}
+
+	return matrix[b.length]![a.length]!;
+}
+
+export function compareStrings(a: string, b: string): number {
+	const aNorm = a.toLowerCase().replace(/\s+/g, " ").trim();
+	const bNorm = b.toLowerCase().replace(/\s+/g, " ").trim();
+	if (aNorm === bNorm) return 1;
+	if (!aNorm || !bNorm) return 0;
+	const distance = levenshtein(aNorm, bNorm);
+	const maxLength = Math.max(aNorm.length, bNorm.length);
+	return 1 - distance / maxLength;
+}
+
+export function strip_presentation_info(term: string): string {
+	let clean = term.replace(/ (feat\.|ft\.|with) .*$/i, "");
+	clean = clean.replace(/ [([](feat\.|ft\.|with).*$/i, "");
+	return clean.trim();
+}

--- a/packages/deezer-sdk/src/utils.ts
+++ b/packages/deezer-sdk/src/utils.ts
@@ -646,7 +646,20 @@ export function compareStrings(a: string, b: string): number {
 }
 
 export function strip_presentation_info(term: string): string {
-	let clean = term.replace(/ (feat\.|ft\.|with) .*$/i, "");
-	clean = clean.replace(/ [([](feat\.|ft\.|with).*$/i, "");
+	let clean = term.replace(/ (feat\.?|ft\.?|with) .*$/i, "");
+	clean = clean.replace(/ [([](feat\.?|ft\.?|with).*$/i, "");
 	return clean.trim();
+}
+
+export function compareStringsTokenSort(a: string, b: string): number {
+	const tokenize = (s: string) =>
+		s
+			.toLowerCase()
+			.replace(/[^\w\s]/g, "")
+			.split(/\s+/)
+			.sort()
+			.join(" ");
+	const aSorted = tokenize(a);
+	const bSorted = tokenize(b);
+	return compareStrings(aSorted, bSorted);
 }

--- a/packages/webui/src/client/utils/utils.ts
+++ b/packages/webui/src/client/utils/utils.ts
@@ -26,7 +26,8 @@ export function isValidURL(text: string): boolean {
 			lowerCaseText.includes("deezer.com") ||
 			lowerCaseText.includes("deezer.page.link") ||
 			lowerCaseText.includes("open.spotify.com") ||
-			lowerCaseText.includes("link.tospotify.com")
+			lowerCaseText.includes("link.tospotify.com") ||
+			lowerCaseText.includes("listenbrainz.org")
 		) {
 			return true;
 		}

--- a/packages/webui/src/server/deemixApp.ts
+++ b/packages/webui/src/server/deemixApp.ts
@@ -11,6 +11,7 @@ import {
 	saveSettings,
 	Single,
 	SpotifyPlugin,
+	ListenBrainzPlugin,
 	utils,
 	type DownloadObject,
 	type Listener,
@@ -44,7 +45,7 @@ export class DeemixApp {
 	deezerAvailable?: DeezerAvailable;
 	latestVersion: string | null;
 
-	plugins: Record<string, SpotifyPlugin>;
+	plugins: Record<string, any>;
 	settings: Settings;
 
 	listener: Listener;
@@ -58,11 +59,13 @@ export class DeemixApp {
 
 		this.plugins = {
 			spotify: new SpotifyPlugin(),
+			listenbrainz: new ListenBrainzPlugin(),
 		};
 		this.latestVersion = null;
 		this.listener = listener;
 
 		this.plugins.spotify.setup();
+		this.plugins.listenbrainz.setup();
 		this.restoreQueueFromDisk();
 	}
 


### PR DESCRIPTION
## Summary

This adds support for listenbrainz playlists - it could be expanded to support JSPF (json version of XSPF) files more widely. Makes it easier to import from listenbrainz playlists instead of relying on broken spotify 

## Screenshots (if applicable)

## Checklist

- [x] I have tested the changes locally and they work as expected
- [x] This PR contains a changeset (`pnpm changeset`)
