### PR TITLE
Fix Spotify API February 2026 breaking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ packages/webui/public/js/*
 .turbo
 tsconfig.tsbuildinfo
 vite.config.*.timestamp-*
+
+# Local project management
+memory-bank/

--- a/packages/deemix/src/plugins/spotify.ts
+++ b/packages/deemix/src/plugins/spotify.ts
@@ -13,9 +13,11 @@ import {
 	SpotifyApi,
 	type MaxInt,
 	type Track as SpotifyTrack,
+	type AccessToken,
 } from "@spotify/web-api-ts-sdk";
 import { queue } from "async";
 import { Deezer, type DeezerTrack } from "deezer-sdk";
+import crypto from "crypto";
 import fs from "fs";
 import got from "got";
 import { sep } from "path";
@@ -38,6 +40,14 @@ export default class SpotifyPlugin extends BasePlugin {
 	configFolder: string;
 	sp: SpotifyApi;
 
+	// OAuth token storage
+	oauthTokens: {
+		accessToken: string;
+		refreshToken: string;
+		expiresAt: number; // Unix timestamp in ms
+	} | null;
+	oauthState: string | null; // CSRF protection
+
 	constructor(configFolder = undefined) {
 		super();
 		this.credentials = { clientId: "", clientSecret: "" };
@@ -45,6 +55,8 @@ export default class SpotifyPlugin extends BasePlugin {
 			fallbackSearch: false,
 		};
 		this.enabled = false;
+		this.oauthTokens = null;
+		this.oauthState = null;
 		/* this.sp */
 		this.configFolder = configFolder || getConfigFolder();
 		this.configFolder += `spotify${sep}`;
@@ -81,7 +93,7 @@ export default class SpotifyPlugin extends BasePlugin {
 		} else if (link.search(/[/:]album[/:](.+)/g) !== -1) {
 			link_type = "album";
 			link_id = /[/:]album[/:](.+)/g.exec(link)[1];
-		} else if (link.search(/[/:]playlist[/:](\d+)/g) !== -1) {
+		} else if (link.search(/[/:]playlist[/:](.+)/g) !== -1) {
 			link_type = "playlist";
 			link_id = /[/:]playlist[/:](.+)/g.exec(link)[1];
 		}
@@ -169,7 +181,16 @@ export default class SpotifyPlugin extends BasePlugin {
 	async generatePlaylistItem(dz: Deezer, link_id: string, bitrate: number) {
 		if (!this.enabled) throw new PluginNotEnabledError("Spotify");
 
-		const spotifyPlaylist = await this.sp.playlists.getPlaylist(link_id);
+		await this.ensureValidToken();
+		let spotifyPlaylist = await this.spotifyApiGet(`/playlists/${link_id}`) as any;
+		if (!spotifyPlaylist) {
+			spotifyPlaylist = await this.sp.playlists.getPlaylist(link_id);
+		}
+
+		// Handle null tracks (Spotify Dev Mode apps return null tracks for public playlists)
+		if (!spotifyPlaylist.tracks) {
+			spotifyPlaylist.tracks = await this.sp.playlists.getPlaylistItems(link_id);
+		}
 
 		const playlistAPI: any = this._convertPlaylistStructure(spotifyPlaylist);
 		playlistAPI.various_artist = await dz.api.get_artist(5080); // Useful for save as compilation
@@ -182,13 +203,16 @@ export default class SpotifyPlugin extends BasePlugin {
 			const offset = parseInt(regExec[1]);
 			const limit = parseInt(regExec[2]) as MaxInt<50>;
 
-			const playlistTracks = await this.sp.playlists.getPlaylistItems(
-				link_id,
-				undefined,
-				undefined,
-				limit,
-				offset
-			);
+			let playlistTracks = await this.spotifyApiGet(`/playlists/${link_id}/tracks?offset=${offset}&limit=${limit}`) as any;
+			if (!playlistTracks) {
+				playlistTracks = await this.sp.playlists.getPlaylistItems(
+					link_id,
+					undefined,
+					undefined,
+					limit,
+					offset
+				);
+			}
 
 			spotifyPlaylist.tracks = playlistTracks;
 			tracklistTemp = tracklistTemp.concat(spotifyPlaylist.tracks.items);
@@ -223,6 +247,7 @@ export default class SpotifyPlugin extends BasePlugin {
 
 	async getTrack(track_id: string, spotifyTrack?: SpotifyTrack) {
 		if (!this.enabled) throw new PluginNotEnabledError("Spotify");
+		await this.ensureValidToken();
 
 		const cachedTrack = {
 			isrc: null,
@@ -230,12 +255,17 @@ export default class SpotifyPlugin extends BasePlugin {
 		};
 
 		if (!spotifyTrack) {
-			try {
-				spotifyTrack = await this.sp.tracks.get(track_id);
-			} catch (e) {
-				if (e.body.error.message === "invalid id")
-					throw new InvalidID(`https://open.spotify.com/track/${track_id}`);
-				throw e;
+			const directTrack = await this.spotifyApiGet(`/tracks/${track_id}`);
+			if (directTrack) {
+				spotifyTrack = directTrack as SpotifyTrack;
+			} else {
+				try {
+					spotifyTrack = await this.sp.tracks.get(track_id);
+				} catch (e) {
+					if (e.body?.error?.message === "invalid id")
+						throw new InvalidID(`https://open.spotify.com/track/${track_id}`);
+					throw e;
+				}
 			}
 		}
 
@@ -259,18 +289,24 @@ export default class SpotifyPlugin extends BasePlugin {
 
 	async getAlbum(album_id: string, spotifyAlbum = null) {
 		if (!this.enabled) throw new PluginNotEnabledError("Spotify");
+		await this.ensureValidToken();
 		const cachedAlbum = {
 			upc: null,
 			data: null,
 		};
 
 		if (!spotifyAlbum) {
-			try {
-				spotifyAlbum = await this.sp.albums.get(album_id);
-			} catch (e) {
-				if (e.body.error.message === "invalid id")
-					throw new InvalidID(`https://open.spotify.com/album/${album_id}`);
-				throw e;
+			const directAlbum = await this.spotifyApiGet(`/albums/${album_id}`);
+			if (directAlbum) {
+				spotifyAlbum = directAlbum;
+			} else {
+				try {
+					spotifyAlbum = await this.sp.albums.get(album_id);
+				} catch (e) {
+					if (e.body?.error?.message === "invalid id")
+						throw new InvalidID(`https://open.spotify.com/album/${album_id}`);
+					throw e;
+				}
 			}
 		}
 		if (spotifyAlbum.external_ids && spotifyAlbum.external_ids.upc)
@@ -423,7 +459,7 @@ export default class SpotifyPlugin extends BasePlugin {
 			id: spotifyPlaylist.id,
 			is_loved_track: false,
 			link: spotifyPlaylist.external_urls.spotify,
-			nb_tracks: spotifyPlaylist.tracks.total,
+			nb_tracks: spotifyPlaylist.tracks?.total ?? 0,
 			picture: cover,
 			picture_small:
 				cover ||
@@ -443,7 +479,7 @@ export default class SpotifyPlugin extends BasePlugin {
 			public: spotifyPlaylist.public,
 			share: spotifyPlaylist.external_urls.spotify,
 			title: spotifyPlaylist.name,
-			tracklist: spotifyPlaylist.tracks.href,
+			tracklist: spotifyPlaylist.tracks?.href ?? '',
 			type: "playlist",
 		};
 
@@ -491,22 +527,29 @@ export default class SpotifyPlugin extends BasePlugin {
 			);
 		}
 		this.setSettings(settings);
+
+		// Load OAuth tokens if present
+		if (settings.oauthTokens) {
+			this.oauthTokens = settings.oauthTokens;
+		}
+
 		this.checkCredentials();
 	}
 
 	saveSettings(newSettings?: any) {
 		if (newSettings) this.setSettings(newSettings);
 		this.checkCredentials();
+		const configData: any = {
+			...this.credentials,
+			...this.settings,
+		};
+		// Persist OAuth tokens if present
+		if (this.oauthTokens) {
+			configData.oauthTokens = this.oauthTokens;
+		}
 		fs.writeFileSync(
 			this.configFolder + "config.json",
-			JSON.stringify(
-				{
-					...this.credentials,
-					...this.settings,
-				},
-				null,
-				2
-			)
+			JSON.stringify(configData, null, 2)
 		);
 	}
 
@@ -514,6 +557,7 @@ export default class SpotifyPlugin extends BasePlugin {
 		return {
 			...this.credentials,
 			...this.settings,
+			oauthAuthenticated: this.isOAuthAuthenticated(),
 		};
 	}
 
@@ -525,6 +569,8 @@ export default class SpotifyPlugin extends BasePlugin {
 		const settings = { ...newSettings };
 		delete settings.clientId;
 		delete settings.clientSecret;
+		delete settings.oauthTokens;
+		delete settings.oauthAuthenticated;
 		this.settings = settings;
 	}
 
@@ -562,11 +608,163 @@ export default class SpotifyPlugin extends BasePlugin {
 			return;
 		}
 
+		// Prefer OAuth tokens if available and valid
+		if (this.oauthTokens && this.oauthTokens.accessToken) {
+			this._initWithOAuthToken();
+			this.enabled = true;
+			return;
+		}
+
+		// Fall back to Client Credentials
 		this.sp = SpotifyApi.withClientCredentials(
 			this.credentials.clientId,
 			this.credentials.clientSecret
 		);
 		this.enabled = true;
+	}
+
+	_initWithOAuthToken() {
+		const token: AccessToken = {
+			access_token: this.oauthTokens.accessToken,
+			token_type: "Bearer",
+			expires_in: Math.max(0, Math.floor((this.oauthTokens.expiresAt - Date.now()) / 1000)),
+			refresh_token: this.oauthTokens.refreshToken,
+		};
+		this.sp = SpotifyApi.withAccessToken(
+			this.credentials.clientId,
+			token
+		);
+	}
+
+	/**
+	 * Direct Spotify API call using got + Bearer token.
+	 * Bypasses the @spotify/web-api-ts-sdk which has issues with withAccessToken.
+	 * Falls back to null if no OAuth tokens, so callers use the SDK instead.
+	 */
+	private async spotifyApiGet(endpoint: string): Promise<any | null> {
+		if (!this.oauthTokens?.accessToken) return null;
+		await this.ensureValidToken();
+		try {
+			const response = await got.get(`https://api.spotify.com/v1${endpoint}`, {
+				headers: {
+					'Authorization': `Bearer ${this.oauthTokens.accessToken}`,
+				},
+			}).json();
+			return response;
+		} catch (e) {
+			// If OAuth request fails, return null to fall back to SDK
+			console.error('[spotify] Direct OAuth API call failed:', e.message);
+			return null;
+		}
+	}
+
+	// --- OAuth Flow Methods ---
+
+	getAuthUrl(redirectUri: string): string {
+		this.oauthState = crypto.randomBytes(16).toString("hex");
+		const scopes = "playlist-read-private";
+		const params = new URLSearchParams({
+			response_type: "code",
+			client_id: this.credentials.clientId,
+			scope: scopes,
+			redirect_uri: redirectUri,
+			state: this.oauthState,
+		});
+		return `https://accounts.spotify.com/authorize?${params.toString()}`;
+	}
+
+	async handleAuthCallback(code: string, redirectUri: string, state: string): Promise<boolean> {
+		// Verify CSRF state
+		if (this.oauthState && state !== this.oauthState) {
+			throw new Error("OAuth state mismatch — possible CSRF attack");
+		}
+		this.oauthState = null;
+
+		// Exchange authorization code for tokens
+		const basicAuth = Buffer.from(
+			`${this.credentials.clientId}:${this.credentials.clientSecret}`
+		).toString("base64");
+
+		const response: any = await got.post("https://accounts.spotify.com/api/token", {
+			headers: {
+				"Authorization": `Basic ${basicAuth}`,
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			form: {
+				grant_type: "authorization_code",
+				code,
+				redirect_uri: redirectUri,
+			},
+		}).json();
+
+		if (!response.access_token) {
+			throw new Error(`Spotify token exchange failed: ${JSON.stringify(response)}`);
+		}
+
+		this.oauthTokens = {
+			accessToken: response.access_token,
+			refreshToken: response.refresh_token,
+			expiresAt: Date.now() + (response.expires_in * 1000),
+		};
+
+		this._initWithOAuthToken();
+		this.enabled = true;
+		this.saveSettings();
+		return true;
+	}
+
+	async refreshAccessToken(): Promise<boolean> {
+		if (!this.oauthTokens?.refreshToken) return false;
+
+		const basicAuth = Buffer.from(
+			`${this.credentials.clientId}:${this.credentials.clientSecret}`
+		).toString("base64");
+
+		try {
+			const response: any = await got.post("https://accounts.spotify.com/api/token", {
+				headers: {
+					"Authorization": `Basic ${basicAuth}`,
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				form: {
+					grant_type: "refresh_token",
+					refresh_token: this.oauthTokens.refreshToken,
+				},
+			}).json();
+
+			if (!response.access_token) return false;
+
+			this.oauthTokens.accessToken = response.access_token;
+			this.oauthTokens.expiresAt = Date.now() + (response.expires_in * 1000);
+			// Spotify may issue a new refresh token
+			if (response.refresh_token) {
+				this.oauthTokens.refreshToken = response.refresh_token;
+			}
+
+			this._initWithOAuthToken();
+			this.saveSettings();
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async ensureValidToken(): Promise<void> {
+		if (!this.oauthTokens) return;
+		// Refresh if token expires within 60 seconds
+		if (Date.now() >= this.oauthTokens.expiresAt - 60000) {
+			await this.refreshAccessToken();
+		}
+	}
+
+	isOAuthAuthenticated(): boolean {
+		return !!(this.oauthTokens?.accessToken);
+	}
+
+	logoutOAuth(): void {
+		this.oauthTokens = null;
+		this.saveSettings();
+		this.checkCredentials(); // Fall back to Client Credentials
 	}
 
 	getCredentials() {

--- a/packages/webui/src/client/views/SettingsPage.vue
+++ b/packages/webui/src/client/views/SettingsPage.vue
@@ -51,6 +51,7 @@ const lastCredentials = ref({
 	clientSecret: "",
 	fallbackSearch: false,
 });
+const spotifyOAuthConnected = ref(false);
 const lastUser = ref("");
 const spotifyUser = ref(localStorage.getItem("spotifyUser") || "");
 const storedAccountNum = localStorage.getItem("accountNum");
@@ -73,12 +74,45 @@ const userLicense = computed(() => {
 	else return "Free";
 });
 
+function handleSpotifyOAuthMessage(event: MessageEvent) {
+	if (event.data === "spotifyOAuthSuccess") {
+		spotifyOAuthConnected.value = true;
+		toast("Spotify connected!", "done");
+	}
+}
+
+function connectSpotify() {
+	// Save settings first so credentials are persisted
+	saveSettings();
+	// Open OAuth login in a popup window
+	const width = 500;
+	const height = 700;
+	const left = window.screenX + (window.innerWidth - width) / 2;
+	const top = window.screenY + (window.innerHeight - height) / 2;
+	window.open(
+		"/api/spotifyLogin",
+		"spotifyOAuth",
+		`width=${width},height=${height},left=${left},top=${top}`
+	);
+}
+
+async function disconnectSpotify() {
+	try {
+		await postToServer("spotifyLogout");
+		spotifyOAuthConnected.value = false;
+		toast("Spotify disconnected", "done");
+	} catch {
+		toast("Failed to disconnect Spotify", "close");
+	}
+}
+
 onMounted(async () => {
 	const { settingsData, defaultSettingsData, spotifyCredentials } =
 		await getSettingsData();
 
 	defaultSettings.value = defaultSettingsData;
 	spotifyFeatures.value = spotifyCredentials;
+	spotifyOAuthConnected.value = !!spotifyCredentials.oauthAuthenticated;
 	initSettings(settingsData, spotifyCredentials);
 
 	if (spotifyUser.value) {
@@ -89,6 +123,7 @@ onMounted(async () => {
 	socket.on("updateSettings", updateSettings);
 	// socket.on('accountChanged', accountChanged)
 	socket.on("familyAccounts", initAccounts);
+	window.addEventListener("message", handleSpotifyOAuthMessage);
 
 	if (clientMode.value) {
 		window.api.receive("downloadFolderSelected", downloadFolderSelected);
@@ -100,6 +135,7 @@ onUnmounted(() => {
 	socket.off("updateSettings");
 	// socket.off('accountChanged')
 	socket.off("familyAccounts");
+	window.removeEventListener("message", handleSpotifyOAuthMessage);
 });
 
 function onTemplateVariableClick(templateName) {
@@ -1347,15 +1383,52 @@ function canDownload(bitrate: number) {
 				<input v-model="spotifyFeatures.clientId" type="text" />
 			</div>
 
-			<div class="input-group">
-				<p class="input-group-text">
-					{{ t("settings.spotify.clientSecret") }}
-				</p>
-				<input v-model="spotifyFeatures.clientSecret" type="password" />
-			</div>
+		<div class="input-group">
+			<p class="input-group-text">
+				{{ t("settings.spotify.clientSecret") }}
+			</p>
+			<input v-model="spotifyFeatures.clientSecret" type="password" />
+		</div>
 
-			<div class="input-group">
-				<p class="input-group-text">{{ t("settings.spotify.username") }}</p>
+		<div class="input-group" style="margin-top: 1rem; margin-bottom: 1rem;">
+			<p class="input-group-text" style="margin-bottom: 0.5rem; font-weight: bold;">Spotify Connection</p>
+			<div style="display: flex; align-items: center; gap: 12px;">
+				<span v-if="spotifyOAuthConnected" style="color: #1db954; display: flex; align-items: center; gap: 6px;">
+					<i class="material-icons" style="font-size: 18px;">check_circle</i>
+					Connected to Spotify
+				</span>
+				<span v-else style="color: #999; display: flex; align-items: center; gap: 6px;">
+					<i class="material-icons" style="font-size: 18px;">cancel</i>
+					Not connected
+				</span>
+			</div>
+			<div style="margin-top: 8px;">
+				<button
+					v-if="!spotifyOAuthConnected"
+					class="btn btn-primary"
+					style="background-color: #1db954; border-color: #1db954;"
+					:disabled="!spotifyFeatures.clientId || !spotifyFeatures.clientSecret"
+					@click="connectSpotify"
+				>
+					<svg style="width: 16px; height: 16px; margin-right: 6px; vertical-align: middle; fill: white;" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m12 24c6.624 0 12-5.376 12-12s-5.376-12-12-12-12 5.376-12 12 5.376 12 12 12zm4.872-6.344v.001c-.807 0-3.356-2.828-10.52-1.36-.189.049-.436.126-.576.126-.915 0-1.09-1.369-.106-1.578 3.963-.875 8.013-.798 11.467 1.268.824.526.474 1.543-.265 1.543zm1.303-3.173c-.113-.03-.08.069-.597-.203-3.025-1.79-7.533-2.512-11.545-1.423-.232.063-.358.126-.576.126-1.071 0-1.355-1.611-.188-1.94 4.716-1.325 9.775-.552 13.297 1.543.392.232.547.533.547.953-.005.522-.411.944-.938.944zm-13.627-7.485c4.523-1.324 11.368-.906 15.624 1.578 1.091.629.662 2.22-.498 2.22l-.001-.001c-.252 0-.407-.063-.625-.189-3.443-2.056-9.604-2.549-13.59-1.436-.175.048-.393.125-.625.125-.639 0-1.127-.499-1.127-1.142 0-.657.407-1.029.842-1.155z"/></svg>
+					Connect with Spotify
+				</button>
+				<button
+					v-else
+					class="btn btn-primary"
+					style="background-color: #666;"
+					@click="disconnectSpotify"
+				>
+					Disconnect
+				</button>
+			</div>
+			<p v-if="!spotifyOAuthConnected && spotifyFeatures.clientId && spotifyFeatures.clientSecret" style="margin-top: 8px; font-size: 0.85em; color: #999;">
+				Save settings first, then click Connect. You'll be redirected to Spotify to authorize.
+			</p>
+		</div>
+
+		<div class="input-group">
+			<p class="input-group-text">{{ t("settings.spotify.username") }}</p>
 				<p class="input-group-text text-sm text-gray-400">
 					{{ t("settings.spotify.usernameHint") }}
 				</p>

--- a/packages/webui/src/server/routes/api/get/index.ts
+++ b/packages/webui/src/server/routes/api/get/index.ts
@@ -17,6 +17,8 @@ import getUserSpotifyPlaylists from "./getUserSpotifyPlaylists.js";
 import getUserFavorites from "./getUserFavorites.js";
 import getQueue from "./getQueue.js";
 import spotifyStatus from "./spotifyStatus.js";
+import spotifyLogin from "./spotifyLogin.js";
+import spotifyCallback from "./spotifyCallback.js";
 import checkForUpdates from "./checkForUpdates.js";
 
 export default [
@@ -39,5 +41,7 @@ export default [
 	getUserFavorites,
 	getQueue,
 	spotifyStatus,
+	spotifyLogin,
+	spotifyCallback,
 	checkForUpdates,
 ];

--- a/packages/webui/src/server/routes/api/get/spotifyCallback.ts
+++ b/packages/webui/src/server/routes/api/get/spotifyCallback.ts
@@ -1,0 +1,37 @@
+import { type ApiHandler } from "../../../types.js";
+
+const path: ApiHandler["path"] = "/spotifyCallback";
+
+const handler: ApiHandler["handler"] = async (req, res) => {
+	const deemix = req.app.get("deemix");
+	const spotify = deemix.plugins.spotify;
+
+	const { code, state, error } = req.query;
+
+	if (error) {
+		res.status(400).send(`<html><body><h2>Spotify Auth Error</h2><p>${error}</p><script>setTimeout(()=>window.close(),3000)</script></body></html>`);
+		return;
+	}
+
+	if (!code || !state) {
+		res.status(400).send(`<html><body><h2>Missing parameters</h2><script>setTimeout(()=>window.close(),3000)</script></body></html>`);
+		return;
+	}
+
+	// Reconstruct the same redirect URI used during login
+	const protocol = req.headers["x-forwarded-proto"] || req.protocol || "http";
+	const host = req.headers["x-forwarded-host"] || req.headers.host;
+	const redirectUri = `${protocol}://${host}/api/spotifyCallback`;
+
+	try {
+		await spotify.handleAuthCallback(code as string, redirectUri, state as string);
+		// Redirect back to the app settings page with success indicator
+		res.send(`<html><body><h2>Spotify Connected!</h2><p>You can close this window.</p><script>if(window.opener){window.opener.postMessage('spotifyOAuthSuccess','*');setTimeout(()=>window.close(),1500)}else{setTimeout(()=>{window.location.href='/'},1500)}</script></body></html>`);
+	} catch (e) {
+		res.status(500).send(`<html><body><h2>Auth Failed</h2><p>${e.message}</p><script>setTimeout(()=>window.close(),5000)</script></body></html>`);
+	}
+};
+
+const apiHandler: ApiHandler = { path, handler };
+
+export default apiHandler;

--- a/packages/webui/src/server/routes/api/get/spotifyLogin.ts
+++ b/packages/webui/src/server/routes/api/get/spotifyLogin.ts
@@ -1,0 +1,25 @@
+import { type ApiHandler } from "../../../types.js";
+
+const path: ApiHandler["path"] = "/spotifyLogin";
+
+const handler: ApiHandler["handler"] = (req, res) => {
+	const deemix = req.app.get("deemix");
+	const spotify = deemix.plugins.spotify;
+
+	if (!spotify.enabled && !spotify.credentials.clientId) {
+		res.status(400).json({ error: "Spotify credentials not configured" });
+		return;
+	}
+
+	// Build redirect URI from the current request origin
+	const protocol = req.headers["x-forwarded-proto"] || req.protocol || "http";
+	const host = req.headers["x-forwarded-host"] || req.headers.host;
+	const redirectUri = `${protocol}://${host}/api/spotifyCallback`;
+
+	const authUrl = spotify.getAuthUrl(redirectUri);
+	res.redirect(authUrl);
+};
+
+const apiHandler: ApiHandler = { path, handler };
+
+export default apiHandler;

--- a/packages/webui/src/server/routes/api/post/index.ts
+++ b/packages/webui/src/server/routes/api/post/index.ts
@@ -8,6 +8,7 @@ import removeFromQueue from "./removeFromQueue.js";
 import logout from "./logout.js";
 import saveSettings from "./saveSettings.js";
 import retryDownload from "./retryDownload.js";
+import spotifyLogout from "./spotifyLogout.js";
 
 export default [
 	changeAccount,
@@ -20,4 +21,5 @@ export default [
 	logout,
 	saveSettings,
 	retryDownload,
+	spotifyLogout,
 ];

--- a/packages/webui/src/server/routes/api/post/spotifyLogout.ts
+++ b/packages/webui/src/server/routes/api/post/spotifyLogout.ts
@@ -1,0 +1,15 @@
+import { type ApiHandler } from "../../../types.js";
+
+const path: ApiHandler["path"] = "/spotifyLogout";
+
+const handler: ApiHandler["handler"] = (req, res) => {
+	const deemix = req.app.get("deemix");
+	const spotify = deemix.plugins.spotify;
+
+	spotify.logoutOAuth();
+	res.json({ success: true, spotifyEnabled: spotify.enabled, oauthAuthenticated: false });
+};
+
+const apiHandler: ApiHandler = { path, handler };
+
+export default apiHandler;


### PR DESCRIPTION
## Fix Spotify API February 2026 Breaking Changes

### Context
Spotify's February 2026 API changes introduced several breaking issues for apps in Development Mode:
- `tracks` field can be null in playlist responses
- `GET /users/{id}` and `GET /users/{id}/playlists` endpoints removed
- Playlist link regex only matched digit-only IDs, but Spotify IDs are alphanumeric (e.g. `37i9dQZF1DXcBWIGoYBM5M`)
- OAuth flow fails silently with new Development Mode API keys returning 403

### Changes

1. **Playlist regex fix** (`spotify.ts` `parseLink()`): Changed `\\d+` to `.+` to match alphanumeric Spotify IDs.

2. **Null `tracks` handling** (`spotify.ts` `_convertPlaylistStructure()` and `generatePlaylistItem()`): Added null checks and optional chaining on `tracks?.total` / `tracks?.href`. When `tracks` is null, falls back to fetching via `getPlaylistItems()` API directly.

3. **OAuth Authorization Code flow** (`spotify.ts` `spotifyApiGet()`): Direct HTTP bypass for cases where SDK `withAccessToken()` returns 403 with new Development Mode keys.

4. **New API routes**:
   - `GET /api/spotifyLogin` — Initiates OAuth flow, redirects to Spotify authorization page
   - `GET /api/spotifyCallback` — Handles OAuth callback, exchanges code for tokens
   - `POST /api/spotifyLogout` — Clears stored OAuth tokens

5. **Settings UI** (`SettingsPage.vue`): Added Spotify OAuth connection section showing connection status and login/logout button.

### Testing
Tested with Spotify playlists, tracks, and albums using new Development Mode API keys (February 2026). All URL types successfully download after applying these fixes.

### Notes
- `external_ids` removal (ISRC/UPC) was already handled by the existing null check in `getTrack()` — no change needed there.
- `GET /users/{id}/playlists` removal affects the sidebar refresh button but does not affect downloading via pasted URL (the primary use case).