### PR TITLE
add optional chaining mapGwTrackToDeezer

### DIFF
--- a/.changeset/fix-media-href-crash.md
+++ b/.changeset/fix-media-href-crash.md
@@ -1,0 +1,5 @@
+---
+"deezer-sdk": patch
+---
+
+Fix crash in `mapGwTrackToDeezer` when Deezer GW API returns tracks without `MEDIA` or `EXPLICIT_TRACK_CONTENT` fields. Added optional chaining to prevent "Cannot read properties of undefined (reading 'HREF')" error when downloading albums.

--- a/packages/deezer-sdk/src/utils.ts
+++ b/packages/deezer-sdk/src/utils.ts
@@ -497,9 +497,10 @@ export function mapGwTrackToDeezer(track: GWTrack): EnrichedAPITrack {
 		release_date: track.PHYSICAL_RELEASE_DATE,
 		explicit_lyrics: Boolean(track.EXPLICIT_LYRICS),
 		explicit_content_lyrics:
-			track.EXPLICIT_TRACK_CONTENT.EXPLICIT_LYRICS_STATUS,
-		explicit_content_cover: track.EXPLICIT_TRACK_CONTENT.EXPLICIT_COVER_STATUS,
-		preview: track.MEDIA[0]?.HREF,
+			track.EXPLICIT_TRACK_CONTENT?.EXPLICIT_LYRICS_STATUS,
+		explicit_content_cover:
+			track.EXPLICIT_TRACK_CONTENT?.EXPLICIT_COVER_STATUS,
+		preview: track.MEDIA?.[0]?.HREF,
 		gain: track.GAIN,
 		lyrics_id: track.LYRICS_ID,
 		physical_release_date: track.PHYSICAL_RELEASE_DATE,


### PR DESCRIPTION
Deezer GW API can return tracks without MEDIA or EXPLICIT_TRACK_CONTENT fields (e.g. geo-blocked or partially available tracks in album listings). This caused "Cannot read properties of undefined (reading 'HREF')" when downloading. Added optional chaining to safely handle missing fields.

## Summary

- Added optional chaining (`?.`) to `track.MEDIA` and `track.EXPLICIT_TRACK_CONTENT` access in `mapGwTrackToDeezer` (`packages/deezer-sdk/src/utils.ts`)
- Prevents TypeError crash when Deezer's GW API returns tracks without these fields, which happens intermittently with newer releases

## Screenshots (if applicable)
<img width="633" height="366" alt="grafik" src="https://github.com/user-attachments/assets/b1c45450-cbc0-4136-b14e-0ccdb4727d2c" />
<img width="1153" height="1000" alt="grafik" src="https://github.com/user-attachments/assets/e3ff89b3-a1fe-431f-b520-c9a459d96256" />

## Checklist

- [x] I have tested the changes locally and they work as expected
- [x] This PR contains a changeset (`pnpm changeset`)****