### PR TITLE
Refactor newReleases handler with error handling

### DIFF
--- a/.changeset/empty-bottles-wish.md
+++ b/.changeset/empty-bottles-wish.md
@@ -1,0 +1,5 @@
+---
+"deemix-webui": minor
+---
+
+Prevent application crash if some content is not available (geo-restricted, else)

--- a/packages/webui/src/server/routes/api/get/newReleases.ts
+++ b/packages/webui/src/server/routes/api/get/newReleases.ts
@@ -6,64 +6,70 @@ import { getAlbumDetails } from "./albumSearch.js";
 const path: ApiHandler["path"] = "/newReleases";
 
 const handler: ApiHandler["handler"] = async (req, res) => {
-	if (!sessionDZ[req.session.id]) sessionDZ[req.session.id] = new Deezer();
-	const dz = sessionDZ[req.session.id];
-
-	const results = await dz.gw.get_page("channels/explore");
-
-	const music_section = results.sections.find((e: any) =>
-		e.section_id.includes("module_id=83718b7b-5503-4062-b8b9-3530e2e2cefa")
-	);
-
-	const channels = music_section.items.map((e: any) => e.target);
-
-	const newReleasesByChannel = <any[][]>(
-		await Promise.all(channels.map((c: string) => channelNewReleases(dz, c)))
-	);
-
-	const seen = new Set();
-	const distinct: any[] = [];
-
-	newReleasesByChannel.forEach((l) => {
-		l.forEach((r) => {
-			if (!seen.has(r.ALB_ID)) {
-				seen.add(r.ALB_ID);
-				distinct.push(r);
-			}
+	try {
+		if (!sessionDZ[req.session.id]) sessionDZ[req.session.id] = new Deezer();
+		const dz = sessionDZ[req.session.id];
+	
+		const results = await dz.gw.get_page("channels/explore");
+	
+		const music_section = results.sections.find((e: any) =>
+			e.section_id.includes("module_id=83718b7b-5503-4062-b8b9-3530e2e2cefa")
+		);
+	
+		const channels = music_section.items.map((e: any) => e.target);
+	
+        const newReleasesByChannel = (await Promise.all(channels.map((c) => channelNewReleases(dz, c).catch((err) => {
+            console.warn(`[newReleases] Skipping channel ${c}: ${err.message}`);
+            return [];
+        }))));
+	
+		const seen = new Set();
+		const distinct: any[] = [];
+	
+		newReleasesByChannel.forEach((l) => {
+			l.forEach((r) => {
+				if (!seen.has(r.ALB_ID)) {
+					seen.add(r.ALB_ID);
+					distinct.push(r);
+				}
+			});
 		});
-	});
-
-	distinct.sort((a, b) =>
-		a.DIGITAL_RELEASE_DATE < b.DIGITAL_RELEASE_DATE
-			? 1
-			: b.DIGITAL_RELEASE_DATE < a.DIGITAL_RELEASE_DATE
-			? -1
-			: 0
-	);
-
-	const now = Date.now();
-	const delta = 8 * 24 * 60 * 60 * 1000;
-
-	const recent = distinct.filter(
-		(x: any) => now - Date.parse(x.DIGITAL_RELEASE_DATE) < delta
-	);
-
-	const albumResults = await Promise.all(
-		recent.map((c: any) =>
-			getAlbumDetails(dz, c.ALB_ID).catch((err: Error) => {
-				console.warn(`[newReleases] Skipping album ${c.ALB_ID}: ${err.message}`);
-				return null;
-			})
-		)
-	);
-	const albums = albumResults.filter((a) => a !== null);
-
-	const output = {
-		data: albums,
-		total: albums.length,
-	};
-
-	res.send(output);
+	
+		distinct.sort((a, b) =>
+			a.DIGITAL_RELEASE_DATE < b.DIGITAL_RELEASE_DATE
+				? 1
+				: b.DIGITAL_RELEASE_DATE < a.DIGITAL_RELEASE_DATE
+				? -1
+				: 0
+		);
+	
+		const now = Date.now();
+		const delta = 8 * 24 * 60 * 60 * 1000;
+	
+		const recent = distinct.filter(
+			(x: any) => now - Date.parse(x.DIGITAL_RELEASE_DATE) < delta
+		);
+	
+		const albumResults = await Promise.all(
+			recent.map((c: any) =>
+				getAlbumDetails(dz, c.ALB_ID).catch((err: Error) => {
+					console.warn(`[newReleases] Skipping album ${c.ALB_ID}: ${err.message}`);
+					return null;
+				})
+			)
+		);
+		const albums = albumResults.filter((a) => a !== null);
+	
+		const output = {
+			data: albums,
+			total: albums.length,
+		};
+	
+		res.send(output);
+    } catch (err) {
+        console.error(`[newReleases] Handler failed: ${err.message}`);
+        res.send({ data: [], total: 0 });
+    }
 };
 
 const apiHandler: ApiHandler = { path, handler };


### PR DESCRIPTION
## Summary

- _What's changed and why?_

`channelNewReleases` can throw (e.g. `GWAPIError: Track unavailable on Deezer`) when Deezer returns unavailable or geo-restricted content in a channel. Previously this propagated as an unhandled promise rejection through the Promise.all, crashing the Node.js process in Node 15+ where unhandled rejections are fatal.

Two fixes:

- Added .catch() on each channelNewReleases call inside the Promise.all, so a single failing channel is skipped with a warning rather than aborting the entire request.
- Wrapped the handler body in a try/catch to ensure any remaining unexpected errors return an empty response ({ data: [], total: 0 }) instead of leaving the request hanging and killing the process.

Fix #292 #164
Related https://github.com/ta264/Lidarr.Plugin.Deemix/pull/26

## Screenshots (if applicable)

## Checklist

- [x] I have tested the changes locally and they work as expected
- [ ] This PR contains a changeset (`pnpm changeset`)
