### PR TITLE
chore(ci): build webui and gui on changes

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -11,7 +11,7 @@ on:
       - .github/workflows/build-publish-docker.yml
       - Dockerfile
       - docker/**
-      - packages/webui/CHANGELOG.md
+      - packages/webui/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-release-electron.yml
+++ b/.github/workflows/build-release-electron.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     paths:
-      - packages/gui/CHANGELOG.md
+      - packages/gui/*
       - .github/workflows/build-release-electron.yml
 
 concurrency:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/*
 
 blockExoticSubdeps: false
+nodeLinker: "hoisted"
 
 allowBuilds:
   electron: true


### PR DESCRIPTION
## Summary

- Trigger CI build for webui and gui package when package contents change
- We already run a `pnpm build` on any changes, but this will ensure we're able to build the docker and electron images

## Screenshots (if applicable)

## Checklist

- [x] I have tested the changes locally and they work as expected
- [ ] This PR contains a changeset (`pnpm changeset`)
