### PR TITLE
chore(repo): add Nix flake for reproducible webui + cli builds

### DIFF
--- a/.changeset/nix-flake.md
+++ b/.changeset/nix-flake.md
@@ -1,0 +1,1 @@
+Add a Nix flake for reproducible builds of the webui server and cli. `nix build .#webui` / `.#cli`, `nix run .#webui`, and `nix develop` for a dev shell.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ You'll probably want to at least map the download and config folders, as well as
 | `-e DISABLE_OWNERSHIP_CHECK_MUSIC=true` | Disable ownership fix on container start for music files  |              |
 | `-e DISABLE_OWNERSHIP_CHECK_DATA=true`  | Disable ownership fix on container start for config files |              |
 
+### Nix Flake
+
+Build and run the webui server or cli reproducibly with [Nix](https://nixos.org) (flakes enabled):
+
+```bash
+nix run github:bambanah/deemix#webui      # start the webui server on 0.0.0.0:6595
+nix run github:bambanah/deemix#cli -- <url>  # download a track/playlist
+
+nix build github:bambanah/deemix#webui    # build only, result in ./result
+```
+
+A dev shell with the pinned node + pnpm is available via `nix develop`.
+
 ## Feature requests
 
 Before asking for a feature make sure there isn't already an [open issue](https://github.com/bambanah/deemix/issues).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,57 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/89570f24e97e614aa34aa9ab1c927b6578a43775.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/89570f24e97e614aa34aa9ab1c927b6578a43775.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "Nix packaging for deemix (webui server + cli)";
+
+  inputs = {
+    # Pinned by explicit rev for reproducibility.
+    nixpkgs.url = "https://github.com/NixOS/nixpkgs/archive/89570f24e97e614aa34aa9ab1c927b6578a43775.tar.gz";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        deemix = pkgs.callPackage ./pkgs/deemix.nix {
+          src = self;
+          nodejs = pkgs.nodejs_24;
+          pnpm = pkgs.pnpm_11;
+        };
+
+        withMain =
+          prog:
+          deemix.overrideAttrs (old: {
+            meta = old.meta // {
+              mainProgram = prog;
+            };
+          });
+      in
+      {
+        packages.default = deemix;
+        packages.webui = withMain "deemix-webui";
+        packages.cli = withMain "deemix-cli";
+
+        apps.webui = {
+          type = "app";
+          program = "${deemix}/bin/deemix-webui";
+        };
+        apps.cli = {
+          type = "app";
+          program = "${deemix}/bin/deemix-cli";
+        };
+        apps.default = self.apps.${system}.webui;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ deemix ];
+          packages = [
+            pkgs.nodejs_24
+            pkgs.pnpm_11
+          ];
+        };
+      }
+    );
+}

--- a/pkgs/deemix.nix
+++ b/pkgs/deemix.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  src,
+  nodejs,
+  pnpm,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  python3,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "deemix";
+  version = "4.6.0";
+
+  inherit src;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    hash = "sha256-4a9/SuTRJoFkCStDTZSrgjXlee0ooMOeCpjAXmjevG4=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+    pnpmConfigHook
+    python3
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    patchShebangs node_modules packages/*/node_modules
+    pnpm run build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/deemix
+    cp -r . $out/share/deemix/
+
+    makeWrapper ${nodejs}/bin/node $out/bin/deemix-webui \
+      --add-flags $out/share/deemix/packages/webui/dist/main.js \
+      --set NODE_ENV production
+
+    makeWrapper ${nodejs}/bin/node $out/bin/deemix-cli \
+      --add-flags $out/share/deemix/packages/cli/dist/main.cjs
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "deemix — Deezer downloader (webui server + cli)";
+    homepage = "https://github.com/bambanah/deemix";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "deemix-webui";
+  };
+})


### PR DESCRIPTION
## Summary
Adds a Nix flake so the webui server and cli can be built and run reproducibly with a single command, no manual node/pnpm setup.

- `flake.nix` — pins nixpkgs, selects node 24 + pnpm 11, wires `callPackage`.
- `pkgs/deemix.nix` — the derivation: offline pnpm deps (`fetchPnpmDeps`), turbo build, installs both runnables.

One shared pnpm-workspace build backs both outputs (they share the workspace `deemix` + `deezer-sdk` deps).

### Usage

```sh
nix build .#webui          # or .#cli, .#default
nix run   .#webui          # server on 0.0.0.0:6595
nix run   .#cli -- <url>
nix develop                # dev shell: node 24 + pnpm 11
```

### Checklist
- [x] I have tested the changes locally and they work as expected
- [x] This PR contains a changeset (pnpm changeset)