### PR TITLE
fix: Spotify API February 2026 breaking changes + dependency updates (supersedes #282 + #263)

### DIFF
--- a/.changeset/nine-lions-enjoy.md
+++ b/.changeset/nine-lions-enjoy.md
@@ -1,0 +1,9 @@
+---
+"deezer-sdk": minor
+"deemix": minor
+"deemix-webui": minor
+"deemix-cli": minor
+"deemix-gui": minor
+---
+
+update all dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ packages/webui/public/js/*
 .turbo
 tsconfig.tsbuildinfo
 vite.config.*.timestamp-*
+
+# Local project management
+memory-bank/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,6 @@
 		"deezer-sdk": "workspace:*"
 	},
 	"devDependencies": {
-		"@yao-pkg/pkg": "^5.15.0"
+		"@yao-pkg/pkg": "^5.16.1"
 	}
 }

--- a/packages/deemix/src/plugins/spotify.ts
+++ b/packages/deemix/src/plugins/spotify.ts
@@ -180,6 +180,51 @@ export default class SpotifyPlugin extends BasePlugin {
 		}
 	}
 
+	// Spotify Feb 2026 migration (Development Mode apps, enforced 9 Mar 2026):
+	// GET /playlists/{id}/tracks was replaced by GET /playlists/{id}/items,
+	// and the shape changed from tracks.items[].track to items.items[].item.
+	// Extended Quota apps still serve the old shape, and the pinned
+	// @spotify/web-api-ts-sdk@1.2.0 still generates /tracks URLs, so every
+	// playlist page is normalized here into the legacy
+	// { items, next, total, href } form (each entry exposing .track).
+	private normalizeTracksPage(page: any): any {
+		if (!page || typeof page !== "object") return page;
+		const rawItems: any[] = Array.isArray((page as any)?.items?.items)
+			? (page as any).items.items
+			: Array.isArray((page as any)?.tracks?.items)
+				? (page as any).tracks.items
+				: Array.isArray((page as any)?.items)
+					? (page as any).items
+					: [];
+		const maybeItemsPage = (page as any)?.items;
+		const source =
+			maybeItemsPage && !Array.isArray(maybeItemsPage)
+				? maybeItemsPage
+				: ((page as any)?.tracks ?? page);
+		const normalizedItems = rawItems.map((entry: any) => {
+			if (!entry || typeof entry !== "object") return entry;
+			const track = entry.item ?? entry.track;
+			if (track && !entry.track) return { ...entry, track };
+			return entry;
+		});
+		return {
+			...source,
+			items: normalizedItems,
+			next: source?.next ?? (page as any)?.next ?? null,
+			total: source?.total ?? (page as any)?.total ?? normalizedItems.length,
+			href: source?.href ?? (page as any)?.href ?? "",
+		};
+	}
+
+	private normalizePlaylistTracksPage(playlist: any): void {
+		if (!playlist || typeof playlist !== "object") return;
+		if (!playlist.tracks && playlist.items) {
+			playlist.tracks = this.normalizeTracksPage(playlist.items);
+		} else if (playlist.tracks) {
+			playlist.tracks = this.normalizeTracksPage(playlist.tracks);
+		}
+	}
+
 	async generatePlaylistItem(dz: Deezer, link_id: string, bitrate: number) {
 		if (!this.enabled) throw new PluginNotEnabledError("Spotify");
 		await this.ensureValidToken();
@@ -209,9 +254,24 @@ export default class SpotifyPlugin extends BasePlugin {
 			}
 		}
 
-		// Handle null tracks (Spotify Dev Mode apps return null tracks for public playlists)
-		if (!spotifyPlaylist.tracks) {
-			spotifyPlaylist.tracks = await this.sp.playlists.getPlaylistItems(link_id);
+		// Normalize Feb 2026 (`items`) and legacy (`tracks`) playlist shapes
+		this.normalizePlaylistTracksPage(spotifyPlaylist);
+
+		// Handle null/missing track pages (Spotify Dev Mode apps return null
+		// tracks for some playlists): try the Feb 2026 `/items` endpoint
+		// first via direct HTTP, then fall back to the SDK (which still
+		// targets `/tracks` and only helps Extended Quota apps).
+		if (!spotifyPlaylist.tracks?.items) {
+			const itemsPage = (await this.spotifyApiGet(
+				`/playlists/${link_id}/items?offset=0&limit=50`
+			)) as any;
+			if (itemsPage) {
+				spotifyPlaylist.tracks = this.normalizeTracksPage(itemsPage);
+			} else {
+				spotifyPlaylist.tracks = this.normalizeTracksPage(
+					await this.sp.playlists.getPlaylistItems(link_id)
+				);
+			}
 		}
 
 		const playlistAPI: any = this._convertPlaylistStructure(spotifyPlaylist);
@@ -225,7 +285,9 @@ export default class SpotifyPlugin extends BasePlugin {
 			const offset = parseInt(regExec[1]);
 			const limit = parseInt(regExec[2]) as MaxInt<50>;
 
-			let playlistTracks = await this.spotifyApiGet(`/playlists/${link_id}/tracks?offset=${offset}&limit=${limit}`) as any;
+			let playlistTracks = (await this.spotifyApiGet(
+				`/playlists/${link_id}/items?offset=${offset}&limit=${limit}`
+			)) as any;
 			if (!playlistTracks) {
 				playlistTracks = await this.sp.playlists.getPlaylistItems(
 					link_id,
@@ -236,16 +298,17 @@ export default class SpotifyPlugin extends BasePlugin {
 				);
 			}
 
-			spotifyPlaylist.tracks = playlistTracks;
+			spotifyPlaylist.tracks = this.normalizeTracksPage(playlistTracks);
 			tracklistTemp = tracklistTemp.concat(spotifyPlaylist.tracks.items);
 		}
 
 		const tracklist: SpotifyTrack[] = [];
 		tracklistTemp.forEach((item) => {
-			if (!item.track) return; // Skip everything that isn't a track
-			if (item.track.explicit && !playlistAPI.explicit)
-				playlistAPI.explicit = true;
-			tracklist.push(item.track);
+			// Feb 2026 shape wraps each entry as `item`; legacy shape uses `track`
+			const track = item?.item ?? item?.track;
+			if (!track) return; // Skip everything that isn't a track
+			if (track.explicit && !playlistAPI.explicit) playlistAPI.explicit = true;
+			tracklist.push(track);
 		});
 		if (!playlistAPI.explicit) playlistAPI.explicit = false;
 
@@ -447,10 +510,11 @@ export default class SpotifyPlugin extends BasePlugin {
 				})
 				.json();
 
-			const trackItems: any[] = Array.isArray(playlist?.tracks?.items)
-				? [...playlist.tracks.items]
+			const trackPage: any = playlist?.items ?? playlist?.tracks;
+			const trackItems: any[] = Array.isArray(trackPage?.items)
+				? [...trackPage.items]
 				: [];
-			let nextUrl: string | null = playlist?.tracks?.next || null;
+			let nextUrl: string | null = trackPage?.next || null;
 
 			while (nextUrl) {
 				const page: any = await got
@@ -468,11 +532,17 @@ export default class SpotifyPlugin extends BasePlugin {
 
 			const tracklist: SpotifyTrack[] = [];
 			for (const item of trackItems) {
-				if (!item?.track || typeof item.track.id !== "string") continue;
-				tracklist.push(item.track);
+				const track = item?.item ?? item?.track;
+				if (!track || typeof track.id !== "string") continue;
+				tracklist.push(track);
 			}
 
 			if (!tracklist.length) return null;
+			const normalized = this.normalizeTracksPage(
+				playlist.tracks ?? playlist.items
+			);
+			playlist.tracks =
+				normalized && typeof normalized === "object" ? normalized : {};
 			playlist.tracks.items = trackItems;
 			playlist.tracks.total = tracklist.length;
 
@@ -733,6 +803,9 @@ export default class SpotifyPlugin extends BasePlugin {
 	}
 
 	_convertPlaylistStructure(spotifyPlaylist) {
+		// Normalize Feb 2026 (`items`) and legacy (`tracks`) shapes so both
+		// Development Mode and Extended Quota responses report correct counts.
+		this.normalizePlaylistTracksPage(spotifyPlaylist);
 		let cover = null;
 		// Mickey: some playlists can be faulty, for example https://open.spotify.com/playlist/7vyEjAGrXOIjqlC8pZRupW
 		if (spotifyPlaylist?.images?.length) cover = spotifyPlaylist.images[0].url;

--- a/packages/deemix/src/plugins/spotify.ts
+++ b/packages/deemix/src/plugins/spotify.ts
@@ -15,9 +15,11 @@ import {
 	SpotifyApi,
 	type MaxInt,
 	type Track as SpotifyTrack,
+	type AccessToken,
 } from "@spotify/web-api-ts-sdk";
 import { queue } from "async";
 import { Deezer, type DeezerTrack } from "deezer-sdk";
+import crypto from "crypto";
 import fs from "fs";
 import got from "got";
 import { sep } from "path";
@@ -40,6 +42,14 @@ export default class SpotifyPlugin extends BasePlugin {
 	configFolder: string;
 	sp: SpotifyApi;
 
+	// OAuth token storage
+	oauthTokens: {
+		accessToken: string;
+		refreshToken: string;
+		expiresAt: number; // Unix timestamp in ms
+	} | null;
+	oauthState: string | null; // CSRF protection
+
 	constructor(configFolder = undefined) {
 		super();
 		this.credentials = { clientId: "", clientSecret: "" };
@@ -47,6 +57,8 @@ export default class SpotifyPlugin extends BasePlugin {
 			fallbackSearch: false,
 		};
 		this.enabled = false;
+		this.oauthTokens = null;
+		this.oauthState = null;
 		/* this.sp */
 		this.configFolder = configFolder || getConfigFolder();
 		this.configFolder += `spotify${sep}`;
@@ -170,28 +182,36 @@ export default class SpotifyPlugin extends BasePlugin {
 
 	async generatePlaylistItem(dz: Deezer, link_id: string, bitrate: number) {
 		if (!this.enabled) throw new PluginNotEnabledError("Spotify");
-		let spotifyPlaylist;
+		await this.ensureValidToken();
+		let spotifyPlaylist = await this.spotifyApiGet(`/playlists/${link_id}`) as any;
 		let market: Market | undefined;
-		try {
-			spotifyPlaylist = await this.sp.playlists.getPlaylist(link_id);
-		} catch (e) {
-			// Some Spotify playlists require a market context to resolve.
-			if (this.getSpotifyErrorStatus(e) === 404) {
-				market = "US";
-				try {
-					spotifyPlaylist = await this.sp.playlists.getPlaylist(
-						link_id,
-						market
-					);
-				} catch (retryError) {
-					if (this.getSpotifyErrorStatus(retryError) === 404) {
-						return this.generatePlaylistItemFromPage(dz, link_id, bitrate);
+		if (!spotifyPlaylist) {
+			// Fall back to SDK, with market retry for region-locked playlists
+			try {
+				spotifyPlaylist = await this.sp.playlists.getPlaylist(link_id);
+			} catch (e) {
+				if (this.getSpotifyErrorStatus(e) === 404) {
+					market = "US";
+					try {
+						spotifyPlaylist = await this.sp.playlists.getPlaylist(
+							link_id,
+							market
+						);
+					} catch (retryError) {
+						if (this.getSpotifyErrorStatus(retryError) === 404) {
+							return this.generatePlaylistItemFromPage(dz, link_id, bitrate);
+						}
+						throw retryError;
 					}
-					throw retryError;
+				} else {
+					throw e;
 				}
-			} else {
-				throw e;
 			}
+		}
+
+		// Handle null tracks (Spotify Dev Mode apps return null tracks for public playlists)
+		if (!spotifyPlaylist.tracks) {
+			spotifyPlaylist.tracks = await this.sp.playlists.getPlaylistItems(link_id);
 		}
 
 		const playlistAPI: any = this._convertPlaylistStructure(spotifyPlaylist);
@@ -205,13 +225,16 @@ export default class SpotifyPlugin extends BasePlugin {
 			const offset = parseInt(regExec[1]);
 			const limit = parseInt(regExec[2]) as MaxInt<50>;
 
-			const playlistTracks = await this.sp.playlists.getPlaylistItems(
-				link_id,
-				market,
-				undefined,
-				limit,
-				offset
-			);
+			let playlistTracks = await this.spotifyApiGet(`/playlists/${link_id}/tracks?offset=${offset}&limit=${limit}`) as any;
+			if (!playlistTracks) {
+				playlistTracks = await this.sp.playlists.getPlaylistItems(
+					link_id,
+					market,
+					undefined,
+					limit,
+					offset
+				);
+			}
 
 			spotifyPlaylist.tracks = playlistTracks;
 			tracklistTemp = tracklistTemp.concat(spotifyPlaylist.tracks.items);
@@ -518,6 +541,7 @@ export default class SpotifyPlugin extends BasePlugin {
 
 	async getTrack(track_id: string, spotifyTrack?: SpotifyTrack) {
 		if (!this.enabled) throw new PluginNotEnabledError("Spotify");
+		await this.ensureValidToken();
 
 		const cachedTrack = {
 			isrc: null,
@@ -525,12 +549,17 @@ export default class SpotifyPlugin extends BasePlugin {
 		};
 
 		if (!spotifyTrack) {
-			try {
-				spotifyTrack = await this.sp.tracks.get(track_id);
-			} catch (e) {
-				if (e.body.error.message === "invalid id")
-					throw new InvalidID(`https://open.spotify.com/track/${track_id}`);
-				throw e;
+			const directTrack = await this.spotifyApiGet(`/tracks/${track_id}`);
+			if (directTrack) {
+				spotifyTrack = directTrack as SpotifyTrack;
+			} else {
+				try {
+					spotifyTrack = await this.sp.tracks.get(track_id);
+				} catch (e) {
+					if (e.body?.error?.message === "invalid id")
+						throw new InvalidID(`https://open.spotify.com/track/${track_id}`);
+					throw e;
+				}
 			}
 		}
 
@@ -554,18 +583,24 @@ export default class SpotifyPlugin extends BasePlugin {
 
 	async getAlbum(album_id: string, spotifyAlbum = null) {
 		if (!this.enabled) throw new PluginNotEnabledError("Spotify");
+		await this.ensureValidToken();
 		const cachedAlbum = {
 			upc: null,
 			data: null,
 		};
 
 		if (!spotifyAlbum) {
-			try {
-				spotifyAlbum = await this.sp.albums.get(album_id);
-			} catch (e) {
-				if (e.body.error.message === "invalid id")
-					throw new InvalidID(`https://open.spotify.com/album/${album_id}`);
-				throw e;
+			const directAlbum = await this.spotifyApiGet(`/albums/${album_id}`);
+			if (directAlbum) {
+				spotifyAlbum = directAlbum;
+			} else {
+				try {
+					spotifyAlbum = await this.sp.albums.get(album_id);
+				} catch (e) {
+					if (e.body?.error?.message === "invalid id")
+						throw new InvalidID(`https://open.spotify.com/album/${album_id}`);
+					throw e;
+				}
 			}
 		}
 		if (spotifyAlbum.external_ids && spotifyAlbum.external_ids.upc)
@@ -718,7 +753,7 @@ export default class SpotifyPlugin extends BasePlugin {
 			id: spotifyPlaylist.id,
 			is_loved_track: false,
 			link: spotifyPlaylist.external_urls.spotify,
-			nb_tracks: spotifyPlaylist.tracks.total,
+			nb_tracks: spotifyPlaylist.tracks?.total ?? 0,
 			picture: cover,
 			picture_small:
 				cover ||
@@ -738,7 +773,7 @@ export default class SpotifyPlugin extends BasePlugin {
 			public: spotifyPlaylist.public,
 			share: spotifyPlaylist.external_urls.spotify,
 			title: spotifyPlaylist.name,
-			tracklist: spotifyPlaylist.tracks.href,
+			tracklist: spotifyPlaylist.tracks?.href ?? '',
 			type: "playlist",
 		};
 
@@ -786,22 +821,29 @@ export default class SpotifyPlugin extends BasePlugin {
 			);
 		}
 		this.setSettings(settings);
+
+		// Load OAuth tokens if present
+		if (settings.oauthTokens) {
+			this.oauthTokens = settings.oauthTokens;
+		}
+
 		this.checkCredentials();
 	}
 
 	saveSettings(newSettings?: any) {
 		if (newSettings) this.setSettings(newSettings);
 		this.checkCredentials();
+		const configData: any = {
+			...this.credentials,
+			...this.settings,
+		};
+		// Persist OAuth tokens if present
+		if (this.oauthTokens) {
+			configData.oauthTokens = this.oauthTokens;
+		}
 		fs.writeFileSync(
 			this.configFolder + "config.json",
-			JSON.stringify(
-				{
-					...this.credentials,
-					...this.settings,
-				},
-				null,
-				2
-			)
+			JSON.stringify(configData, null, 2)
 		);
 	}
 
@@ -809,6 +851,7 @@ export default class SpotifyPlugin extends BasePlugin {
 		return {
 			...this.credentials,
 			...this.settings,
+			oauthAuthenticated: this.isOAuthAuthenticated(),
 		};
 	}
 
@@ -820,6 +863,8 @@ export default class SpotifyPlugin extends BasePlugin {
 		const settings = { ...newSettings };
 		delete settings.clientId;
 		delete settings.clientSecret;
+		delete settings.oauthTokens;
+		delete settings.oauthAuthenticated;
 		this.settings = settings;
 	}
 
@@ -857,11 +902,163 @@ export default class SpotifyPlugin extends BasePlugin {
 			return;
 		}
 
+		// Prefer OAuth tokens if available and valid
+		if (this.oauthTokens && this.oauthTokens.accessToken) {
+			this._initWithOAuthToken();
+			this.enabled = true;
+			return;
+		}
+
+		// Fall back to Client Credentials
 		this.sp = SpotifyApi.withClientCredentials(
 			this.credentials.clientId,
 			this.credentials.clientSecret
 		);
 		this.enabled = true;
+	}
+
+	_initWithOAuthToken() {
+		const token: AccessToken = {
+			access_token: this.oauthTokens.accessToken,
+			token_type: "Bearer",
+			expires_in: Math.max(0, Math.floor((this.oauthTokens.expiresAt - Date.now()) / 1000)),
+			refresh_token: this.oauthTokens.refreshToken,
+		};
+		this.sp = SpotifyApi.withAccessToken(
+			this.credentials.clientId,
+			token
+		);
+	}
+
+	/**
+	 * Direct Spotify API call using got + Bearer token.
+	 * Bypasses the @spotify/web-api-ts-sdk which has issues with withAccessToken.
+	 * Falls back to null if no OAuth tokens, so callers use the SDK instead.
+	 */
+	private async spotifyApiGet(endpoint: string): Promise<any | null> {
+		if (!this.oauthTokens?.accessToken) return null;
+		await this.ensureValidToken();
+		try {
+			const response = await got.get(`https://api.spotify.com/v1${endpoint}`, {
+				headers: {
+					'Authorization': `Bearer ${this.oauthTokens.accessToken}`,
+				},
+			}).json();
+			return response;
+		} catch (e) {
+			// If OAuth request fails, return null to fall back to SDK
+			console.error('[spotify] Direct OAuth API call failed:', e.message);
+			return null;
+		}
+	}
+
+	// --- OAuth Flow Methods ---
+
+	getAuthUrl(redirectUri: string): string {
+		this.oauthState = crypto.randomBytes(16).toString("hex");
+		const scopes = "playlist-read-private";
+		const params = new URLSearchParams({
+			response_type: "code",
+			client_id: this.credentials.clientId,
+			scope: scopes,
+			redirect_uri: redirectUri,
+			state: this.oauthState,
+		});
+		return `https://accounts.spotify.com/authorize?${params.toString()}`;
+	}
+
+	async handleAuthCallback(code: string, redirectUri: string, state: string): Promise<boolean> {
+		// Verify CSRF state
+		if (this.oauthState && state !== this.oauthState) {
+			throw new Error("OAuth state mismatch — possible CSRF attack");
+		}
+		this.oauthState = null;
+
+		// Exchange authorization code for tokens
+		const basicAuth = Buffer.from(
+			`${this.credentials.clientId}:${this.credentials.clientSecret}`
+		).toString("base64");
+
+		const response: any = await got.post("https://accounts.spotify.com/api/token", {
+			headers: {
+				"Authorization": `Basic ${basicAuth}`,
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			form: {
+				grant_type: "authorization_code",
+				code,
+				redirect_uri: redirectUri,
+			},
+		}).json();
+
+		if (!response.access_token) {
+			throw new Error(`Spotify token exchange failed: ${JSON.stringify(response)}`);
+		}
+
+		this.oauthTokens = {
+			accessToken: response.access_token,
+			refreshToken: response.refresh_token,
+			expiresAt: Date.now() + (response.expires_in * 1000),
+		};
+
+		this._initWithOAuthToken();
+		this.enabled = true;
+		this.saveSettings();
+		return true;
+	}
+
+	async refreshAccessToken(): Promise<boolean> {
+		if (!this.oauthTokens?.refreshToken) return false;
+
+		const basicAuth = Buffer.from(
+			`${this.credentials.clientId}:${this.credentials.clientSecret}`
+		).toString("base64");
+
+		try {
+			const response: any = await got.post("https://accounts.spotify.com/api/token", {
+				headers: {
+					"Authorization": `Basic ${basicAuth}`,
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				form: {
+					grant_type: "refresh_token",
+					refresh_token: this.oauthTokens.refreshToken,
+				},
+			}).json();
+
+			if (!response.access_token) return false;
+
+			this.oauthTokens.accessToken = response.access_token;
+			this.oauthTokens.expiresAt = Date.now() + (response.expires_in * 1000);
+			// Spotify may issue a new refresh token
+			if (response.refresh_token) {
+				this.oauthTokens.refreshToken = response.refresh_token;
+			}
+
+			this._initWithOAuthToken();
+			this.saveSettings();
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async ensureValidToken(): Promise<void> {
+		if (!this.oauthTokens) return;
+		// Refresh if token expires within 60 seconds
+		if (Date.now() >= this.oauthTokens.expiresAt - 60000) {
+			await this.refreshAccessToken();
+		}
+	}
+
+	isOAuthAuthenticated(): boolean {
+		return !!(this.oauthTokens?.accessToken);
+	}
+
+	logoutOAuth(): void {
+		this.oauthTokens = null;
+		this.saveSettings();
+		this.checkCredentials(); // Fall back to Client Credentials
 	}
 
 	getCredentials() {

--- a/packages/webui/src/client/views/SettingsPage.vue
+++ b/packages/webui/src/client/views/SettingsPage.vue
@@ -49,6 +49,7 @@ const lastCredentials = ref({
 	clientSecret: "",
 	fallbackSearch: false,
 });
+const spotifyOAuthConnected = ref(false);
 const lastUser = ref("");
 const spotifyUser = ref(localStorage.getItem("spotifyUser") || "");
 const storedAccountNum = localStorage.getItem("accountNum");
@@ -71,12 +72,45 @@ const userLicense = computed(() => {
 	else return "Free";
 });
 
+function handleSpotifyOAuthMessage(event: MessageEvent) {
+	if (event.data === "spotifyOAuthSuccess") {
+		spotifyOAuthConnected.value = true;
+		toast("Spotify connected!", "done");
+	}
+}
+
+function connectSpotify() {
+	// Save settings first so credentials are persisted
+	saveSettings();
+	// Open OAuth login in a popup window
+	const width = 500;
+	const height = 700;
+	const left = window.screenX + (window.innerWidth - width) / 2;
+	const top = window.screenY + (window.innerHeight - height) / 2;
+	window.open(
+		"/api/spotifyLogin",
+		"spotifyOAuth",
+		`width=${width},height=${height},left=${left},top=${top}`
+	);
+}
+
+async function disconnectSpotify() {
+	try {
+		await postToServer("spotifyLogout");
+		spotifyOAuthConnected.value = false;
+		toast("Spotify disconnected", "done");
+	} catch {
+		toast("Failed to disconnect Spotify", "close");
+	}
+}
+
 onMounted(async () => {
 	const { settingsData, defaultSettingsData, spotifyCredentials } =
 		await getSettingsData();
 
 	defaultSettings.value = defaultSettingsData;
 	spotifyFeatures.value = spotifyCredentials;
+	spotifyOAuthConnected.value = !!spotifyCredentials.oauthAuthenticated;
 	initSettings(settingsData, spotifyCredentials);
 
 	if (spotifyUser.value) {
@@ -87,6 +121,7 @@ onMounted(async () => {
 	socket.on("updateSettings", updateSettings);
 	// socket.on('accountChanged', accountChanged)
 	socket.on("familyAccounts", initAccounts);
+	window.addEventListener("message", handleSpotifyOAuthMessage);
 
 	if (clientMode.value) {
 		window.api.receive("downloadFolderSelected", downloadFolderSelected);
@@ -98,6 +133,7 @@ onUnmounted(() => {
 	socket.off("updateSettings");
 	// socket.off('accountChanged')
 	socket.off("familyAccounts");
+	window.removeEventListener("message", handleSpotifyOAuthMessage);
 });
 
 function onTemplateVariableClick(templateName) {
@@ -1299,15 +1335,52 @@ function canDownload(bitrate: number) {
 				<input v-model="spotifyFeatures.clientId" type="text" />
 			</div>
 
-			<div class="input-group">
-				<p class="input-group-text">
-					{{ t("settings.spotify.clientSecret") }}
-				</p>
-				<input v-model="spotifyFeatures.clientSecret" type="password" />
-			</div>
+		<div class="input-group">
+			<p class="input-group-text">
+				{{ t("settings.spotify.clientSecret") }}
+			</p>
+			<input v-model="spotifyFeatures.clientSecret" type="password" />
+		</div>
 
-			<div class="input-group">
-				<p class="input-group-text">{{ t("settings.spotify.username") }}</p>
+		<div class="input-group" style="margin-top: 1rem; margin-bottom: 1rem;">
+			<p class="input-group-text" style="margin-bottom: 0.5rem; font-weight: bold;">Spotify Connection</p>
+			<div style="display: flex; align-items: center; gap: 12px;">
+				<span v-if="spotifyOAuthConnected" style="color: #1db954; display: flex; align-items: center; gap: 6px;">
+					<i class="material-icons" style="font-size: 18px;">check_circle</i>
+					Connected to Spotify
+				</span>
+				<span v-else style="color: #999; display: flex; align-items: center; gap: 6px;">
+					<i class="material-icons" style="font-size: 18px;">cancel</i>
+					Not connected
+				</span>
+			</div>
+			<div style="margin-top: 8px;">
+				<button
+					v-if="!spotifyOAuthConnected"
+					class="btn btn-primary"
+					style="background-color: #1db954; border-color: #1db954;"
+					:disabled="!spotifyFeatures.clientId || !spotifyFeatures.clientSecret"
+					@click="connectSpotify"
+				>
+					<svg style="width: 16px; height: 16px; margin-right: 6px; vertical-align: middle; fill: white;" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m12 24c6.624 0 12-5.376 12-12s-5.376-12-12-12-12 5.376-12 12 5.376 12 12 12zm4.872-6.344v.001c-.807 0-3.356-2.828-10.52-1.36-.189.049-.436.126-.576.126-.915 0-1.09-1.369-.106-1.578 3.963-.875 8.013-.798 11.467 1.268.824.526.474 1.543-.265 1.543zm1.303-3.173c-.113-.03-.08.069-.597-.203-3.025-1.79-7.533-2.512-11.545-1.423-.232.063-.358.126-.576.126-1.071 0-1.355-1.611-.188-1.94 4.716-1.325 9.775-.552 13.297 1.543.392.232.547.533.547.953-.005.522-.411.944-.938.944zm-13.627-7.485c4.523-1.324 11.368-.906 15.624 1.578 1.091.629.662 2.22-.498 2.22l-.001-.001c-.252 0-.407-.063-.625-.189-3.443-2.056-9.604-2.549-13.59-1.436-.175.048-.393.125-.625.125-.639 0-1.127-.499-1.127-1.142 0-.657.407-1.029.842-1.155z"/></svg>
+					Connect with Spotify
+				</button>
+				<button
+					v-else
+					class="btn btn-primary"
+					style="background-color: #666;"
+					@click="disconnectSpotify"
+				>
+					Disconnect
+				</button>
+			</div>
+			<p v-if="!spotifyOAuthConnected && spotifyFeatures.clientId && spotifyFeatures.clientSecret" style="margin-top: 8px; font-size: 0.85em; color: #999;">
+				Save settings first, then click Connect. You'll be redirected to Spotify to authorize.
+			</p>
+		</div>
+
+		<div class="input-group">
+			<p class="input-group-text">{{ t("settings.spotify.username") }}</p>
 				<p class="input-group-text text-sm text-gray-400">
 					{{ t("settings.spotify.usernameHint") }}
 				</p>

--- a/packages/webui/src/server/routes/api/get/index.ts
+++ b/packages/webui/src/server/routes/api/get/index.ts
@@ -17,6 +17,8 @@ import getUserSpotifyPlaylists from "./getUserSpotifyPlaylists.js";
 import getUserFavorites from "./getUserFavorites.js";
 import getQueue from "./getQueue.js";
 import spotifyStatus from "./spotifyStatus.js";
+import spotifyLogin from "./spotifyLogin.js";
+import spotifyCallback from "./spotifyCallback.js";
 import checkForUpdates from "./checkForUpdates.js";
 
 export default [
@@ -39,5 +41,7 @@ export default [
 	getUserFavorites,
 	getQueue,
 	spotifyStatus,
+	spotifyLogin,
+	spotifyCallback,
 	checkForUpdates,
 ];

--- a/packages/webui/src/server/routes/api/get/spotifyCallback.ts
+++ b/packages/webui/src/server/routes/api/get/spotifyCallback.ts
@@ -1,0 +1,37 @@
+import { type ApiHandler } from "../../../types.js";
+
+const path: ApiHandler["path"] = "/spotifyCallback";
+
+const handler: ApiHandler["handler"] = async (req, res) => {
+	const deemix = req.app.get("deemix");
+	const spotify = deemix.plugins.spotify;
+
+	const { code, state, error } = req.query;
+
+	if (error) {
+		res.status(400).send(`<html><body><h2>Spotify Auth Error</h2><p>${error}</p><script>setTimeout(()=>window.close(),3000)</script></body></html>`);
+		return;
+	}
+
+	if (!code || !state) {
+		res.status(400).send(`<html><body><h2>Missing parameters</h2><script>setTimeout(()=>window.close(),3000)</script></body></html>`);
+		return;
+	}
+
+	// Reconstruct the same redirect URI used during login
+	const protocol = req.headers["x-forwarded-proto"] || req.protocol || "http";
+	const host = req.headers["x-forwarded-host"] || req.headers.host;
+	const redirectUri = `${protocol}://${host}/api/spotifyCallback`;
+
+	try {
+		await spotify.handleAuthCallback(code as string, redirectUri, state as string);
+		// Redirect back to the app settings page with success indicator
+		res.send(`<html><body><h2>Spotify Connected!</h2><p>You can close this window.</p><script>if(window.opener){window.opener.postMessage('spotifyOAuthSuccess','*');setTimeout(()=>window.close(),1500)}else{setTimeout(()=>{window.location.href='/'},1500)}</script></body></html>`);
+	} catch (e) {
+		res.status(500).send(`<html><body><h2>Auth Failed</h2><p>${e.message}</p><script>setTimeout(()=>window.close(),5000)</script></body></html>`);
+	}
+};
+
+const apiHandler: ApiHandler = { path, handler };
+
+export default apiHandler;

--- a/packages/webui/src/server/routes/api/get/spotifyLogin.ts
+++ b/packages/webui/src/server/routes/api/get/spotifyLogin.ts
@@ -1,0 +1,25 @@
+import { type ApiHandler } from "../../../types.js";
+
+const path: ApiHandler["path"] = "/spotifyLogin";
+
+const handler: ApiHandler["handler"] = (req, res) => {
+	const deemix = req.app.get("deemix");
+	const spotify = deemix.plugins.spotify;
+
+	if (!spotify.enabled && !spotify.credentials.clientId) {
+		res.status(400).json({ error: "Spotify credentials not configured" });
+		return;
+	}
+
+	// Build redirect URI from the current request origin
+	const protocol = req.headers["x-forwarded-proto"] || req.protocol || "http";
+	const host = req.headers["x-forwarded-host"] || req.headers.host;
+	const redirectUri = `${protocol}://${host}/api/spotifyCallback`;
+
+	const authUrl = spotify.getAuthUrl(redirectUri);
+	res.redirect(authUrl);
+};
+
+const apiHandler: ApiHandler = { path, handler };
+
+export default apiHandler;

--- a/packages/webui/src/server/routes/api/post/index.ts
+++ b/packages/webui/src/server/routes/api/post/index.ts
@@ -7,6 +7,7 @@ import removeFromQueue from "./removeFromQueue.js";
 import logout from "./logout.js";
 import saveSettings from "./saveSettings.js";
 import retryDownload from "./retryDownload.js";
+import spotifyLogout from "./spotifyLogout.js";
 
 export default [
 	changeAccount,
@@ -18,4 +19,5 @@ export default [
 	logout,
 	saveSettings,
 	retryDownload,
+	spotifyLogout,
 ];

--- a/packages/webui/src/server/routes/api/post/spotifyLogout.ts
+++ b/packages/webui/src/server/routes/api/post/spotifyLogout.ts
@@ -1,0 +1,15 @@
+import { type ApiHandler } from "../../../types.js";
+
+const path: ApiHandler["path"] = "/spotifyLogout";
+
+const handler: ApiHandler["handler"] = (req, res) => {
+	const deemix = req.app.get("deemix");
+	const spotify = deemix.plugins.spotify;
+
+	spotify.logoutOAuth();
+	res.json({ success: true, spotifyEnabled: spotify.enabled, oauthAuthenticated: false });
+};
+
+const apiHandler: ApiHandler = { path, handler };
+
+export default apiHandler;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         version: link:../deezer-sdk
     devDependencies:
       '@yao-pkg/pkg':
-        specifier: ^5.15.0
+        specifier: ^5.16.1
         version: 5.16.1(encoding@0.1.13)(supports-color@5.5.0)
 
   packages/deemix:


### PR DESCRIPTION
## Summary

This PR supersedes both **#282** (@peanutlasko Spotify API fixes) and **#263** (@Dreamer269 dependency updates). The original #282 is 38 commits behind main with zero reviews and merge conflicts — this rebases it onto current `main`, resolves conflicts, and bundles the dependency hardening.

All original credit for the Spotify fixes goes to @peanutlasko.

---

## What Spotify Broke (February 2026)

Spotify February 2026 API changes introduced **three breaking changes** for apps using Development Mode API keys:

| Change | Effect on Deemix |
|--------|------------------|
| `tracks` field can now be `null` in playlist responses | `Cannot read properties of undefined (reading 'total')` crash |
| `GET /users/{id}` and `GET /users/{id}/playlists` removed | Username lookup broken ("not a valid spotify username") |
| Playlist IDs are now alphanumeric (e.g. `37i9dQZF1DXcBWIGoYBM5M`) | Regex `\\d+` fails to match — silent failure on Spotify-curated playlists |
| OAuth SDK returns 403 for Development Mode keys | Silent auth failure, 502 Bad Gateway in web UI |

---

## Changes

### From #282 (Spotify API fixes — @peanutlasko)

| File | Change |
|------|--------|
| `spotify.ts` | OAuth Authorization Code flow with `spotifyApiGet()` direct HTTP bypass, null `tracks` handling via optional chaining, alphanumeric playlist ID regex, token refresh with `ensureValidToken()`, CSRF-protected state management |
| `SettingsPage.vue` | "Connect with Spotify" OAuth button with connected/disconnected status |
| `spotifyLogin.ts` **(new)** | Initiates OAuth flow → redirects to Spotify authorization |
| `spotifyCallback.ts` **(new)** | Handles OAuth callback, exchanges authorization code for tokens, saves to config |
| `spotifyLogout.ts` **(new)** | Clears stored OAuth tokens, falls back to Client Credentials |
| `index.ts` (get + post routes) | Registers new OAuth API routes |

### Conflict Resolutions (vs current main)

The main branch added **market-fallback logic** in `generatePlaylistItem()` (try without market → retry with `market="US"` → fallback to `generatePlaylistItemFromPage`). This PR merges that with the OAuth changes:

- `spotifyApiGet()` is tried FIRST (uses OAuth token if available)
- Falls back to SDK `getPlaylist()` with market retry (preserving main logic)
- Null `tracks` check runs after both paths
- Pagination in `getPlaylistItems()` carries through the `market` parameter

### From #263 (Dependency updates — @Dreamer269)

- `pnpm update` across all workspace packages (7 package files + lockfile)
- Reduces `pnpm audit` vulnerabilities from **>27 → 5**
- Tested locally by original author

---

## Issues Fixed

- Fixes **#304** — `undefined - cannot read properties of undefined reading 'total'`
- Fixes **#293** — "Spotify feature no longer working"
- Fixes **#277** — "Spotify created playlists cannot be downloaded"
- Fixes **#337** — "Spotify Feature 502"
- Fixes **#295** — "Cannot read properties of undefined (reading 'mp3_320')"

---

## Prerequisites for the Spotify Feature

### Deployment Options

**Option A — Localhost (simplest, same-machine only)**
- Browser and deemix on the **same machine**
- No Spotify app registration needed — `localhost` is always allowed by Spotify
- No HTTPS needed
- Redirect URI: `http://localhost:6595/api/spotifyCallback`

**Option B — Domain with reverse proxy (recommended for servers)**
- Deemix accessible via a **domain name** (e.g. `deemix.example.com`)
- **HTTPS required** — Spotify rejects `http://` for non-localhost URIs
- A reverse proxy (nginx, Caddy, Traefik) providing TLS
- Register the redirect URI in the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard):
  ```
  https://<your-domain>/api/spotifyCallback
  ```
- The PR code auto-detects the correct URI from request headers (`x-forwarded-proto` + `host`) — no hardcoding needed

### Spotify Account
- **Spotify Premium** required (Spotify restricted API access to Premium accounts in 2026)
- Create a Spotify Developer app at https://developer.spotify.com/dashboard
- Note the `clientId` and `clientSecret`

---

## How the OAuth Flow Works

```
User clicks "Connect" → GET /api/spotifyLogin → Spotify authorize page
→ User approves → Spotify redirects to /api/spotifyCallback?code=...&state=...
→ Server exchanges code for tokens via POST https://accounts.spotify.com/api/token
→ Access token + refresh token saved to config/spotify/config.json
→ Popup sends postMessage to parent → settings UI updates to "Connected"
→ All subsequent API calls use Bearer token (with automatic refresh 60s before expiry)
```

---

## Testing

Tested with Spotify playlists, tracks, and albums using **Development Mode API keys** (July 2026):

| URL type | Status |
|----------|--------|
| Track (`/track/...`) | ✅ Downloads |
| Album (`/album/...`) | ✅ Downloads |
| User playlist (`/playlist/...`) | ✅ Downloads |
| Spotify-curated playlist (alphanumeric ID) | ✅ Downloads |
| Region-locked playlist | ✅ Fallback to web scraping |

Tested behind Caddy reverse proxy with HTTPS and dynamic redirect URI detection.

---

## Known Limitations

1. **Re-auth after server restart**: OAuth tokens persist to disk (`config.json`), but in testing the Settings page sometimes needs a manual disconnect/reconnect cycle to pick them up after a restart. The token refresh logic works — it is a UI state issue, not an auth issue. @peanutlasko noted this in the original PR discussion.

2. **HTTPS required for remote access**: Spotify rejects `http://` redirect URIs for non-localhost domains. A reverse proxy with valid TLS is mandatory for LAN/cloud deployments. `localhost` setups can use plain HTTP.

3. **Client Credentials fallback**: If no OAuth tokens are available, the plugin falls back to Spotify Client Credentials flow. This gets a generic API token but cannot access user-specific data or playlists requiring the `playlist-read-private` scope. OAuth is the recommended path.

---

## Migration from pre-Feb-2026 Deemix

If you are upgrading from a version that used the old username-based Spotify config:

1. The `spotifyUsername` field is no longer used (Spotify removed the endpoint)
2. You need a Spotify Developer app with OAuth credentials (Client ID + Secret)
3. After upgrading, go to Settings → Spotify → enter credentials → Connect
4. Existing config files are backward-compatible — credentials are loaded from the same `config.json`

---

## Checklist

- [x] Rebased onto current `main` (commit `3ac2576`, re-rebased 6 Sep 2026)
- [x] Merge conflicts resolved (market-fallback + OAuth changes merged)
- [x] Types compile cleanly (`tsc` + `vue-tsc`, all packages, exit 0)
- [x] Tested with real Spotify Development Mode keys
- [x] All original credit preserved (co-authored-by both PR authors)
- [x] Dependency updates applied (vulnerabilities >27→5)
- [x] No hardcoded domains or credentials in the diff
- [x] Redirect URI detection is dynamic (no hardcoding)